### PR TITLE
elipsize chapter list in the middle

### DIFF
--- a/app/src/main/res/layout/item_chapter.xml
+++ b/app/src/main/res/layout/item_chapter.xml
@@ -66,7 +66,7 @@
             android:layout_alignParentTop="true"
             android:layout_alignWithParentIfMissing="true"
             android:layout_marginRight="30dp"
-            android:ellipsize="end"
+            android:ellipsize="middle"
             android:gravity="center_vertical"
             android:maxLines="1"
             android:textSize="17sp"


### PR DESCRIPTION
Fixes chapter number not being visible on long manga names (see https://github.com/inorichi/tachiyomi/issues/54)

![](https://i.imgur.com/a7N1y2e.png)

A nicer, more complex solution might be to split the chapter name between manga name and chapter number and only elipsize the manga name on the end, leaving the chapter number visible