### PR TITLE
Added different image fit styles

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.java
@@ -88,6 +88,10 @@ public class PreferencesHelper {
         return prefs.getInt(getKey(R.string.pref_default_viewer_key), 1);
     }
 
+    public int getImageFit(){
+        return prefs.getInt(getKey(R.string.pref_default_fit_key),3);
+    }
+
     public Preference<Integer> portraitColumns() {
         return rxPrefs.getInteger(getKey(R.string.pref_library_columns_portrait_key), 0);
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerReaderFragment.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerReaderFragment.java
@@ -66,6 +66,7 @@ public class PagerReaderFragment extends BaseFragment {
         imageView.setDoubleTapZoomStyle(SubsamplingScaleImageView.ZOOM_FOCUS_FIXED);
         imageView.setPanLimit(SubsamplingScaleImageView.PAN_LIMIT_INSIDE);
         imageView.setMinimumScaleType(SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE);
+        imageView.setInternalScaleType(activity.getPreferences().getImageFit());
         imageView.setRegionDecoderClass(parentFragment.getRegionDecoderClass());
         imageView.setOnTouchListener((v, motionEvent) -> parentFragment.onImageTouch(motionEvent));
         imageView.setOnImageEventListener(new SubsamplingScaleImageView.DefaultOnImageEventListener() {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -14,6 +14,17 @@
         <item>4</item>
     </string-array>
 
+    <string-array name="fit_mode">
+        <item>@string/fit_to_width</item>
+        <item>@string/fit_to_height</item>
+        <item>@string/smart_fit</item>
+    </string-array>
+    <string-array name="fit_mode_values">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+
     <string-array name="viewers_selector">
         <item>@string/default_viewer</item>
         <item>@string/left_to_right_viewer</item>

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -16,6 +16,7 @@
     <string name="pref_ask_update_manga_sync_key">pref_ask_update_manga_sync_key</string>
 
     <string name="pref_default_viewer_key">pref_default_viewer_key</string>
+    <string name="pref_default_fit_key">pref_default_fit_key</string>
     <string name="pref_hide_status_bar_key">pref_hide_status_bar_key</string>
     <string name="pref_lock_orientation_key">pref_lock_orientation_key</string>
     <string name="pref_enable_transitions_key">pref_enable_transitions_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,10 @@
     <string name="right_to_left_viewer">Right to left</string>
     <string name="vertical_viewer">Vertical</string>
     <string name="webtoon_viewer">Webtoon (experimental)</string>
+    <string name="image_fit_type">Image fitter</string>
+    <string name="smart_fit">Smart Fit</string>
+    <string name="fit_to_width">Fit to Width</string>
+    <string name="fit_to_height">Fit to Height</string>
     <string name="pref_image_decoder">Image decoder</string>
     <string name="rapid_decoder">Rapid</string>
     <string name="skia_decoder">Skia</string>

--- a/app/src/main/res/xml/pref_reader.xml
+++ b/app/src/main/res/xml/pref_reader.xml
@@ -18,6 +18,14 @@
         android:defaultValue="true" />
 
     <eu.kanade.tachiyomi.widget.preference.IntListPreference
+        android:title="Image fit"
+        android:key="@string/pref_default_fit_key"
+        android:entries="@array/fit_mode"
+        android:entryValues="@array/fit_mode_values"
+        android:defaultValue="3"
+        android:summary="%s"/>
+
+    <eu.kanade.tachiyomi.widget.preference.IntListPreference
         android:title="@string/pref_viewer_type"
         android:key="@string/pref_default_viewer_key"
         android:entries="@array/viewers"


### PR DESCRIPTION
As was requested by many people, a setting has been generated to fit an image to the width of the screen(very useful for landscape mode on tablets).
Available settings are: fit image to width, to height, to smaller dimension (smart_fit). 
Related to #40, #67, #85 and #92