### PR TITLE
Improve chapter number parsing

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.java
@@ -94,6 +94,19 @@ public class ChapterRecognition {
 
         // TODO more checks (maybe levenshtein?)
 
+        // try splitting the name in parts an pick the first valid one
+        String[] nameParts = chapter.name.split("-");
+        if (nameParts.length > 1) {
+            Chapter dummyChapter = Chapter.create();
+            for (String part : nameParts) {
+                dummyChapter.name = part;
+                parseChapterNumber(dummyChapter, manga);
+                if (dummyChapter.chapter_number >= 0) {
+                    chapter.chapter_number = dummyChapter.chapter_number;
+                    return;
+                }
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.java
@@ -12,6 +12,7 @@ public class ChapterRecognition {
 
     private static final Pattern cleanWithToken = Pattern.compile("ch[^0-9]?\\s*(\\d+[\\.,]?\\d+)($|\\b)");
     private static final Pattern uncleanWithToken = Pattern.compile("ch[^0-9]?\\s*(\\d+[\\.,]?\\d*)");
+    private static final Pattern withAlphaPostfix = Pattern.compile("(\\d+[\\.,]?\\d*\\s*)([a-z])($|\\b)");
     private static final Pattern cleanNumber = Pattern.compile("(\\d+[\\.,]?\\d+)($|\\b)");
     private static final Pattern uncleanNumber = Pattern.compile("(\\d+[\\.,]?\\d*)");
     private static final Pattern withColon = Pattern.compile("(\\d+[\\.,]?\\d*\\s*:)");
@@ -30,6 +31,13 @@ public class ChapterRecognition {
         matcher = cleanWithToken.matcher(name);
         if (matcher.find()) {
             chapter.chapter_number = Float.parseFloat(matcher.group(1));
+            return;
+        }
+
+        // a number with a single alpha prefix is parsed as sub-chapter
+        matcher = withAlphaPostfix.matcher(name);
+        if (matcher.find()) {
+            chapter.chapter_number = Float.parseFloat(matcher.group(1)) + parseAlphaPostFix(matcher.group(2));
             return;
         }
 
@@ -86,6 +94,14 @@ public class ChapterRecognition {
 
         // TODO more checks (maybe levenshtein?)
 
+    }
+
+    /**
+     * x.a -> x.1, x.b -> x.2, etc
+     */
+    private static float parseAlphaPostFix(String postfix) {
+        char alpha = postfix.charAt(0);
+        return Float.parseFloat("0." + Integer.toString((int)alpha - 96));
     }
 
     public static List<Float> getAllOccurrences(Matcher matcher) {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.java
@@ -19,6 +19,8 @@ public class ChapterRecognition {
 
     private static final Pattern pUnwanted =
             Pattern.compile("(\\b|\\d)(v|ver|vol|version|volume)\\.?\\s*\\d+\\b");
+    private static final Pattern pPart =
+            Pattern.compile("(\\b|\\d)part\\s*\\d+.+");
 
     public static void parseChapterNumber(Chapter chapter, Manga manga) {
         if (chapter.chapter_number != -1)
@@ -96,8 +98,8 @@ public class ChapterRecognition {
 
         // try splitting the name in parts an pick the first valid one
         String[] nameParts = chapter.name.split("-");
+        Chapter dummyChapter = Chapter.create();
         if (nameParts.length > 1) {
-            Chapter dummyChapter = Chapter.create();
             for (String part : nameParts) {
                 dummyChapter.name = part;
                 parseChapterNumber(dummyChapter, manga);
@@ -106,6 +108,15 @@ public class ChapterRecognition {
                     return;
                 }
             }
+        }
+
+        // Strip anything after "part xxx" and try that
+        name = pPart.matcher(name).replaceAll("$1");
+        dummyChapter.name = name;
+        parseChapterNumber(dummyChapter, manga);
+        if (dummyChapter.chapter_number >= 0) {
+            chapter.chapter_number = dummyChapter.chapter_number;
+            return;
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.java
@@ -15,7 +15,7 @@ public class ChapterRecognition {
     private static final Pattern p3 = Pattern.compile("(\\d+[\\.,]?\\d*\\s*:)");
 
     private static final Pattern pUnwanted =
-            Pattern.compile("\\b(v|ver|vol|version|volume)\\.?\\s*\\d+\\b");
+            Pattern.compile("(\\b|\\d)(v|ver|vol|version|volume)\\.?\\s*\\d+\\b");
 
     public static void parseChapterNumber(Chapter chapter, Manga manga) {
         if (chapter.chapter_number != -1)
@@ -32,7 +32,7 @@ public class ChapterRecognition {
         }
 
         // Remove anything related to the volume or version
-        name = pUnwanted.matcher(name).replaceAll("");
+        name = pUnwanted.matcher(name).replaceAll("$1");
 
         List<Float> occurrences;
 

--- a/app/src/test/java/eu/kanade/tachiyomi/ChapterRecognitionTest.java
+++ b/app/src/test/java/eu/kanade/tachiyomi/ChapterRecognitionTest.java
@@ -148,4 +148,14 @@ public class ChapterRecognitionTest {
         ChapterRecognition.parseChapterNumber(c, randomManga);
         assertThat(c.chapter_number).isEqualTo(99f);
     }
+
+    @Test
+    public void testAlphaSubChapters() {
+        Chapter c = createChapter("Asu No Yoichi 19a");
+        ChapterRecognition.parseChapterNumber(c, randomManga);
+        assertThat(c.chapter_number).isEqualTo(19.1f);
+        c = createChapter("Asu No Yoichi 19b");
+        ChapterRecognition.parseChapterNumber(c, randomManga);
+        assertThat(c.chapter_number).isEqualTo(19.2f);
+    }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ChapterRecognitionTest.java
+++ b/app/src/test/java/eu/kanade/tachiyomi/ChapterRecognitionTest.java
@@ -158,4 +158,11 @@ public class ChapterRecognitionTest {
         ChapterRecognition.parseChapterNumber(c, randomManga);
         assertThat(c.chapter_number).isEqualTo(19.2f);
     }
+
+    @Test
+    public void testChapterWithArcNumber() {
+        Chapter c = createChapter("Manga title 123 - Vol 016 Arc title 002");
+        ChapterRecognition.parseChapterNumber(c, randomManga);
+        assertThat(c.chapter_number).isEqualTo(123f);
+    }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ChapterRecognitionTest.java
+++ b/app/src/test/java/eu/kanade/tachiyomi/ChapterRecognitionTest.java
@@ -165,4 +165,11 @@ public class ChapterRecognitionTest {
         ChapterRecognition.parseChapterNumber(c, randomManga);
         assertThat(c.chapter_number).isEqualTo(123f);
     }
+
+    @Test
+    public void testChapterWithChapterPrefixAfterPart() {
+        Chapter c = createChapter("Tokyo ESP 027: Part 002: Chapter 001");
+        ChapterRecognition.parseChapterNumber(c, randomManga);
+        assertThat(c.chapter_number).isEqualTo(027f);
+    }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ChapterRecognitionTest.java
+++ b/app/src/test/java/eu/kanade/tachiyomi/ChapterRecognitionTest.java
@@ -141,4 +141,11 @@ public class ChapterRecognitionTest {
         ChapterRecognition.parseChapterNumber(c, randomManga);
         assertThat(c.chapter_number).isEqualTo(11f);
     }
+
+    @Test
+    public void testWithNumberInChapterTitle() {
+        Chapter c = createChapter("Ansatsu Kyoushitsu 099 Present Time - 2nd Hour");
+        ChapterRecognition.parseChapterNumber(c, randomManga);
+        assertThat(c.chapter_number).isEqualTo(99f);
+    }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ChapterRecognitionTest.java
+++ b/app/src/test/java/eu/kanade/tachiyomi/ChapterRecognitionTest.java
@@ -135,4 +135,10 @@ public class ChapterRecognitionTest {
         assertThat(c.chapter_number).isEqualTo(28f);
     }
 
+    @Test
+    public void testWithVolumeAttachedToChapter() {
+        Chapter c = createChapter("Ansatsu Kyoushitsu 011v002: Assembly Time");
+        ChapterRecognition.parseChapterNumber(c, randomManga);
+        assertThat(c.chapter_number).isEqualTo(11f);
+    }
 }


### PR DESCRIPTION
Adds supports for the follow scenarios:

- chapter versions directly attached to the chapter number (chapter 002v2)
- chapter titles with non-freestanding numbers in the title (chapter 002 foobar the 2nd)
- subchapter denoted by an alpha prefix (chapter 002a, chapter 002b)
- chapter titles with arc numbers (chapter 123 - foo arc 002)
- chapters with numbers in part descriptions (chapter 002 part 001)

This fixes all chapter number issues I've run into so far