### PR TITLE
Make CONTRIBUTING.md more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 [![fdroid release](https://img.shields.io/badge/release-F--Droid-blue.svg)](https://f-droid.org/repository/browse/?fdid=eu.kanade.tachiyomi)
 [![latest debug build](https://img.shields.io/badge/debug-latest%20build-blue.svg)](http://tachiyomi.kanade.eu/latest/app-debug.apk)
 
+## [Report an issue](https://github.com/inorichi/tachiyomi/blob/master/CONTRIBUTING.md)
+
+**Before reporting a new issue, take a look at the [FAQ](https://github.com/inorichi/tachiyomi/wiki/FAQ), the [changelog](https://github.com/inorichi/tachiyomi/releases) and the already opened issues.**
+
 Tachiyomi is a free and open source manga reader for Android.
 
 Keep in mind it's still a beta, so expect it to crash sometimes.
-
-Before reporting a new issue, take a look at the [FAQ](https://github.com/inorichi/tachiyomi/wiki/FAQ), the [changelog](https://github.com/inorichi/tachiyomi/releases) and the already opened issues.
 
 ## Features
 


### PR DESCRIPTION
The worst issue reports come from newly created github accounts. Such users probably look around the page, see issue, click there, see New issue, click there, see a textbox and they start writing, ignoring anything else (like `Please review the guidelines for contributing to this repository.`).
Hope it helps