### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/vertical/VerticalViewPagerImpl.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/vertical/VerticalViewPagerImpl.java
@@ -120,11 +120,11 @@ public class VerticalViewPagerImpl extends ViewGroup {
     private int mExpectedAdapterCount;
 
     static class ItemInfo {
-        Object object;
-        int position;
-        boolean scrolling;
-        float heightFactor;
-        float offset;
+        private Object object;
+        private int position;
+        private boolean scrolling;
+        private float heightFactor;
+        private float offset;
     }
 
     private static final Comparator<ItemInfo> COMPARATOR = new Comparator<ItemInfo>(){
@@ -1260,9 +1260,9 @@ public class VerticalViewPagerImpl extends ViewGroup {
      * contains that state.
      */
     public static class SavedState extends BaseSavedState {
-        int position;
-        Parcelable adapterState;
-        ClassLoader loader;
+        private int position;
+        private Parcelable adapterState;
+        private ClassLoader loader;
 
         public SavedState(Parcelable superState) {
             super(superState);
@@ -2946,23 +2946,23 @@ public class VerticalViewPagerImpl extends ViewGroup {
         /**
          * Width as a 0-1 multiplier of the measured pager width
          */
-        float heightFactor = 0.f;
+        private float heightFactor = 0.f;
 
         /**
          * true if this view was added during layout and needs to be measured
          * before being positioned.
          */
-        boolean needsMeasure;
+        private boolean needsMeasure;
 
         /**
          * Adapter position this view is for if !isDecor
          */
-        int position;
+        private int position;
 
         /**
          * Current child index within the ViewPager that this view occupies
          */
-        int childIndex;
+        private int childIndex;
 
         public LayoutParams() {
             super(FILL_PARENT, FILL_PARENT);

--- a/app/src/main/java/eu/kanade/tachiyomi/util/DynamicConcurrentMergeOperator.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/DynamicConcurrentMergeOperator.java
@@ -17,8 +17,8 @@ import rx.subscriptions.CompositeSubscription;
 import rx.subscriptions.Subscriptions;
 
 public class DynamicConcurrentMergeOperator<T, R> implements Operator<R, T> {
-    final Func1<? super T, ? extends Observable<? extends R>> mapper;
-    final Observable<Integer> workerCount;
+    private final Func1<? super T, ? extends Observable<? extends R>> mapper;
+    private final Observable<Integer> workerCount;
 
     public DynamicConcurrentMergeOperator(
             Func1<? super T, ? extends Observable<? extends R>> mapper,
@@ -37,14 +37,14 @@ public class DynamicConcurrentMergeOperator<T, R> implements Operator<R, T> {
     }
 
     static final class DynamicConcurrentMerge<T, R> extends Subscriber<T> {
-        final Subscriber<? super R> actual;
-        final Func1<? super T, ? extends Observable<? extends R>> mapper;
-        final Queue<T> queue;
-        final CopyOnWriteArrayList<DynamicWorker<T, R>> workers;
-        final CompositeSubscription composite;
-        final AtomicInteger wipActive;
-        final AtomicBoolean once;
-        long id;
+        private final Subscriber<? super R> actual;
+        private final Func1<? super T, ? extends Observable<? extends R>> mapper;
+        private final Queue<T> queue;
+        private final CopyOnWriteArrayList<DynamicWorker<T, R>> workers;
+        private final CompositeSubscription composite;
+        private final AtomicInteger wipActive;
+        private final AtomicBoolean once;
+        private long id;
 
         public DynamicConcurrentMerge(Subscriber<? super R> actual,
                                       Func1<? super T, ? extends Observable<? extends R>> mapper) {
@@ -121,10 +121,10 @@ public class DynamicConcurrentMergeOperator<T, R> implements Operator<R, T> {
     }
 
     static final class DynamicWorker<T, R> {
-        final long id;
-        final AtomicBoolean running;
-        final DynamicConcurrentMerge<T, R> parent;
-        final AtomicBoolean stop;
+        private final long id;
+        private final AtomicBoolean running;
+        private final DynamicConcurrentMerge<T, R> parent;
+        private final AtomicBoolean stop;
 
         public DynamicWorker(long id, DynamicConcurrentMerge<T, R> parent) {
             this.id = id;

--- a/app/src/main/java/eu/kanade/tachiyomi/widget/EndlessGridScrollListener.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/widget/EndlessGridScrollListener.java
@@ -10,7 +10,7 @@ public class EndlessGridScrollListener extends RecyclerView.OnScrollListener {
     private int previousTotal = 0; // The total number of items in the dataset after the last load
     private boolean loading = true; // True if we are still waiting for the last set of data to load.
     private int visibleThreshold = 5; // The minimum amount of items to have below your current scroll position before loading more.
-    int firstVisibleItem, visibleItemCount, totalItemCount;
+    private int firstVisibleItem, visibleItemCount, totalItemCount;
 
     private GridLayoutManager layoutManager;
 

--- a/app/src/main/java/eu/kanade/tachiyomi/widget/EndlessListScrollListener.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/widget/EndlessListScrollListener.java
@@ -10,7 +10,7 @@ public class EndlessListScrollListener extends RecyclerView.OnScrollListener {
     private int previousTotal = 0; // The total number of items in the dataset after the last load
     private boolean loading = true; // True if we are still waiting for the last set of data to load.
     private int visibleThreshold = 5; // The minimum amount of items to have below your current scroll position before loading more.
-    int firstVisibleItem, visibleItemCount, totalItemCount;
+    private int firstVisibleItem, visibleItemCount, totalItemCount;
 
     private LinearLayoutManager layoutManager;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat