### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/ChapterTable.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/ChapterTable.java
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.data.database.tables;
 
 import android.support.annotation.NonNull;
 
-public class ChapterTable {
+public final class ChapterTable {
 
     @NonNull
     public static final String TABLE = "chapters";
@@ -33,6 +33,10 @@ public class ChapterTable {
 
 	@NonNull
 	public static final String COLUMN_CHAPTER_NUMBER = "chapter_number";
+
+	private ChapterTable() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
 
 	@NonNull
 	public static String getCreateTableQuery() {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/MangaSyncTable.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/MangaSyncTable.java
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.data.database.tables;
 
 import android.support.annotation.NonNull;
 
-public class MangaSyncTable {
+public final class MangaSyncTable {
 
     public static final String TABLE = "manga_sync";
 
@@ -23,6 +23,10 @@ public class MangaSyncTable {
     public static final String COLUMN_SCORE = "score";
 
     public static final String COLUMN_TOTAL_CHAPTERS = "total_chapters";
+
+    private MangaSyncTable() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     @NonNull
     public static String getCreateTableQuery() {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/AndroidComponentUtil.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/AndroidComponentUtil.java
@@ -8,7 +8,11 @@ import android.content.pm.PackageManager;
 
 import timber.log.Timber;
 
-public class AndroidComponentUtil {
+public final class AndroidComponentUtil {
+
+    private AndroidComponentUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     public static void toggleComponent(Context context, Class componentClass, boolean enable) {
         Timber.i((enable ? "Enabling " : "Disabling ") + componentClass.getSimpleName());

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 import eu.kanade.tachiyomi.data.database.models.Chapter;
 import eu.kanade.tachiyomi.data.database.models.Manga;
 
-public class ChapterRecognition {
+public final class ChapterRecognition {
 
     private static final Pattern cleanWithToken = Pattern.compile("ch[^0-9]?\\s*(\\d+[\\.,]?\\d+)($|\\b)");
     private static final Pattern uncleanWithToken = Pattern.compile("ch[^0-9]?\\s*(\\d+[\\.,]?\\d*)");
@@ -22,6 +22,10 @@ public class ChapterRecognition {
             Pattern.compile("(\\b|\\d)(v|ver|vol|version|volume)\\.?\\s*\\d+\\b");
     private static final Pattern pPart =
             Pattern.compile("(\\b|\\d)part\\s*\\d+.+");
+
+    private ChapterRecognition() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     public static void parseChapterNumber(Chapter chapter, Manga manga) {
         if (chapter.chapter_number != -1)

--- a/app/src/main/java/eu/kanade/tachiyomi/util/GLUtil.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/GLUtil.java
@@ -5,7 +5,11 @@ import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.egl.EGLContext;
 import javax.microedition.khronos.egl.EGLDisplay;
 
-public class GLUtil {
+public final class GLUtil {
+
+    private GLUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     public static int getMaxTextureSize() {
         // Safe minimum default size

--- a/app/src/main/java/eu/kanade/tachiyomi/util/Parser.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/Parser.java
@@ -5,7 +5,11 @@ import android.support.annotation.Nullable;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
-public class Parser {
+public final class Parser {
+
+    private Parser() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     @Nullable
     public static Element element(Element container, String pattern) {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/UrlUtil.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/UrlUtil.java
@@ -3,11 +3,15 @@ package eu.kanade.tachiyomi.util;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-public class UrlUtil {
+public final class UrlUtil {
 
     private static final String JPG = ".jpg";
     private static final String PNG = ".png";
     private static final String GIF = ".gif";
+
+    private UrlUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     public static String getPath(String s) {
         try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat