### PR TITLE
Release version manual update hotfix.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsAboutFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsAboutFragment.kt
@@ -53,6 +53,7 @@ class SettingsAboutFragment : SettingsNestedFragment() {
         if (!BuildConfig.DEBUG && BuildConfig.INCLUDE_UPDATER) {
             //Set onClickListener to check for new version
             version.setOnPreferenceClickListener {
+                checkVersion()
                 true
             }
 


### PR DESCRIPTION
Accidentally removed the manual check. This means you can't update within the app when 2.1 is installed.