### PR TITLE
Wrong versionName when not building latest version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ ext {
     // Git is needed in your system PATH for these commands to work.
     // If it's not installed, you can return a random value as a workaround
     getCommitCount = {
-        return 'git rev-list --count origin/master'.execute().text.trim()
+        return 'git rev-list --count HEAD'.execute().text.trim()
         // return "1"
     }
 


### PR DESCRIPTION
Fix issue when building version other than the latest one. Occurs when there are two commits in short timespan