### PR TITLE
Rename "Only update incomplete manga" string to "ongoing"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,7 +85,7 @@
     <string name="pref_library_update_restriction_summary">Update only when the conditions are met</string>
     <string name="wifi">Wi-Fi</string>
     <string name="charging">Charging</string>
-    <string name="pref_update_only_non_completed">Only update incomplete manga</string>
+    <string name="pref_update_only_non_completed">Only update ongoing manga</string>
     <string name="pref_auto_update_manga_sync">Sync chapters after reading</string>
     <string name="pref_ask_update_manga_sync">Confirm before updating</string>
     <string name="pref_theme">Application theme</string>


### PR DESCRIPTION
All English manga sources use either Ongoing or Completed, so Tachiyomi using a different term for ongoing manga feels off.