### PR TITLE
Multiple quality improvements - squid:S1213, squid:S1943, squid:S1066

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/injection/ComponentReflectionInjector.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/injection/ComponentReflectionInjector.java
@@ -40,6 +40,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class ComponentReflectionInjector<T> {
 
+    private static final ConcurrentHashMap<Class<?>, HashMap<Class<?>, Method>> cache = new ConcurrentHashMap<>();
+
     private final Class<T> componentClass;
     private final T component;
     private final HashMap<Class<?>, Method> methods;
@@ -73,8 +75,6 @@ public final class ComponentReflectionInjector<T> {
             throw new RuntimeException(e);
         }
     }
-
-    private static final ConcurrentHashMap<Class<?>, HashMap<Class<?>, Method>> cache = new ConcurrentHashMap<>();
 
     private static HashMap<Class<?>, Method> getMethods(Class componentClass) {
         HashMap<Class<?>, Method> methods = cache.get(componentClass);

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/vertical/VerticalViewPagerImpl.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/vertical/VerticalViewPagerImpl.java
@@ -1141,10 +1141,8 @@ public class VerticalViewPagerImpl extends ViewGroup {
                 for (int i=0; i<getChildCount(); i++) {
                     View child = getChildAt(i);
                     ii = infoForChild(child);
-                    if (ii != null && ii.position == mCurItem) {
-                        if (child.requestFocus(focusDirection)) {
-                            break;
-                        }
+                    if (ii != null && ii.position == mCurItem && child.requestFocus(focusDirection)) {
+                        break;
                     }
                 }
             }
@@ -1264,8 +1262,30 @@ public class VerticalViewPagerImpl extends ViewGroup {
         private Parcelable adapterState;
         private ClassLoader loader;
 
+        public static final Parcelable.Creator<SavedState> CREATOR
+                = ParcelableCompat.newCreator(new ParcelableCompatCreatorCallbacks<SavedState>() {
+            @Override
+            public SavedState createFromParcel(Parcel in, ClassLoader loader) {
+                return new SavedState(in, loader);
+            }
+            @Override
+            public SavedState[] newArray(int size) {
+                return new SavedState[size];
+            }
+        });
+
         public SavedState(Parcelable superState) {
             super(superState);
+        }
+
+        SavedState(Parcel in, ClassLoader loader) {
+            super(in);
+            if (loader == null) {
+                loader = getClass().getClassLoader();
+            }
+            position = in.readInt();
+            adapterState = in.readParcelable(loader);
+            this.loader = loader;
         }
 
         @Override
@@ -1282,27 +1302,6 @@ public class VerticalViewPagerImpl extends ViewGroup {
                     + " position=" + position + "}";
         }
 
-        public static final Parcelable.Creator<SavedState> CREATOR
-                = ParcelableCompat.newCreator(new ParcelableCompatCreatorCallbacks<SavedState>() {
-            @Override
-            public SavedState createFromParcel(Parcel in, ClassLoader loader) {
-                return new SavedState(in, loader);
-            }
-            @Override
-            public SavedState[] newArray(int size) {
-                return new SavedState[size];
-            }
-        });
-
-        SavedState(Parcel in, ClassLoader loader) {
-            super(in);
-            if (loader == null) {
-                loader = getClass().getClassLoader();
-            }
-            position = in.readInt();
-            adapterState = in.readParcelable(loader);
-            this.loader = loader;
-        }
     }
 
     @Override
@@ -1956,11 +1955,9 @@ public class VerticalViewPagerImpl extends ViewGroup {
                     if (DEBUG) Log.v(TAG, "Starting unable to drag!");
                     mIsUnableToDrag = true;
                 }
-                if (mIsBeingDragged) {
-                    // Scroll to follow the motion event
-                    if (performDrag(y)) {
-                        ViewCompat.postInvalidateOnAnimation(this);
-                    }
+                // Scroll to follow the motion event
+                if (mIsBeingDragged && performDrag(y)) {
+                    ViewCompat.postInvalidateOnAnimation(this);
                 }
                 break;
             }
@@ -2811,10 +2808,8 @@ public class VerticalViewPagerImpl extends ViewGroup {
             View child = getChildAt(i);
             if (child.getVisibility() == VISIBLE) {
                 ItemInfo ii = infoForChild(child);
-                if (ii != null && ii.position == mCurItem) {
-                    if (child.requestFocus(direction, previouslyFocusedRect)) {
-                        return true;
-                    }
+                if (ii != null && ii.position == mCurItem && child.requestFocus(direction, previouslyFocusedRect)) {
+                    return true;
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/DiskUtils.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/DiskUtils.java
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -15,7 +16,7 @@ public final class DiskUtils {
         String cacheKey;
         try {
             final MessageDigest mDigest = MessageDigest.getInstance("MD5");
-            mDigest.update(key.getBytes());
+            mDigest.update(key.getBytes(StandardCharsets.UTF_8));
             cacheKey = bytesToHexString(mDigest.digest());
         } catch (NoSuchAlgorithmException e) {
             cacheKey = String.valueOf(key.hashCode());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order
squid:S1943 - Classes and methods that rely on the default system encoding should not be used
squid:S1066 - Collapsible "if" statements should be merged

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1066

Please let me know if you have any questions.

M-Ezzat