### PR TITLE
Handle pulled manga in MangaHere

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/source/online/english/Mangahere.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/source/online/english/Mangahere.kt
@@ -102,7 +102,7 @@ class Mangahere(context: Context, override val id: Int) : ParsedOnlineSource(con
     }
 
     override fun pageListParse(document: Document, pages: MutableList<Page>) {
-        document.select("select.wid60").first().getElementsByTag("option").forEach {
+        document.select("select.wid60").first()?.getElementsByTag("option")?.forEach {
             pages.add(Page(pages.size, it.attr("value")))
         }
         pages.getOrNull(0)?.imageUrl = imageUrlParse(document)


### PR DESCRIPTION
Using MangaHere on pulled manga led to a NullPointerError and [corresponding non-informative toast](http://imgur.com/wCzQtMK). This gives an empty page list instead (try reading a chapter of Nisekoi to test), which is technically true and far more informative.

Giving a reason to the user beyond "Empty Page list" would be a good idea in the future (this seems to be one holdup for #220), but there doesn't seem to be an obvious place to put it without touching the base classes.  In the meantime, this one-line fix is far more useful than null pointer errors.