### PR TITLE
Changed minSdkVersion to 15 instead of 16

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         applicationId "eu.kanade.tachiyomi"
-        minSdkVersion 16
+        minSdkVersion 15
         targetSdkVersion 23
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         versionCode 9


### PR DESCRIPTION
I’ve got an Onyx Book Android ebook running 4.0.4 . minSdkVErsion 16 prevented the app from being installed, while changing to 15 allowed it to build and install correctly (and, first tests confirmed that is compatible).

Are you using any >15 specific functionality I need to check for compatibility (and in case try to implement a workaround)?