### PR TITLE
Update Mangasee chapter selector

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/source/online/english/Mangasee.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/source/online/english/Mangasee.kt
@@ -77,7 +77,7 @@ class Mangasee(context: Context, override val id: Int) : ParsedOnlineSource(cont
         else -> Manga.UNKNOWN
     }
 
-    override fun chapterListSelector() = "div.row > div > div.row:has(a.chapter_link[alt])"
+    override fun chapterListSelector() = "div.row > div > div.row > div > div.row:has(a.chapter_link[alt])"
 
     override fun chapterFromElement(element: Element, chapter: Chapter) {
         val urlElement = element.select("a").first()


### PR DESCRIPTION
Current selector is not precise enough and is duplicating the last chapter in chapter list.