### PR TITLE
MAL switched to SSL/HTTPS

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/mangasync/myanimelist/MyAnimeList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/mangasync/myanimelist/MyAnimeList.kt
@@ -26,7 +26,7 @@ class MyAnimeList(private val context: Context, id: Int) : MangaSyncService(cont
     private lateinit var headers: Headers
 
     companion object {
-        val BASE_URL = "http://myanimelist.net"
+        val BASE_URL = "https://myanimelist.net"
 
         private val ENTRY_TAG = "entry"
         private val CHAPTER_TAG = "chapter"


### PR DESCRIPTION
MAL has added support for HTTPS/TLS and is discontinuing HTTP based API endpoints. All API endpoints are to be HTTPS.

As per [https://myanimelist.net/forum/?topicid=1543851](https://myanimelist.net/forum/?topicid=1543851)
> Also, in order to allow our 3rd party developers ample time to update their applications, we’ve decided to allow our API to support both HTTP and HTTPS for about 3 weeks. Please update your application(s) as soon as possible. By mid-September, the API endpoints will only use HTTPS.


I have tested this changed by adding a new manga to MAL, updated chapters, and changed MAL status and rating. However, no further testing has been conducted.
I have confirmed that  communication to MAL is via TLS using a packet capture, compared to HTTP before.