### PR TITLE
HotFix for 1-page mangas not properly updating with MAL

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -421,8 +421,11 @@ class ReaderPresenter : BasePresenter<ReaderActivity>() {
 
         val prevChapter = prevChapter
 
+        // Manga with only 1 page won't update, since they'll be marked as read after this function
+        val chapterSize = chapter.pages?.size
+
         // Get the last chapter read from the reader.
-        val lastChapterRead = if (chapter.read)
+        val lastChapterRead = if (chapter.read  || chapterSize == 1)
             Math.floor(chapter.chapter_number.toDouble()).toInt()
         else if (prevChapter != null && prevChapter.read)
             Math.floor(prevChapter.chapter_number.toDouble()).toInt()


### PR DESCRIPTION
The updating routine starts with `onBackPressed()` in `ReaderActivity.kt`
It will ask for the chapter number which should be used for the update with `getMangaSyncChapterToUpdate()` in `ReaderPresenter.kt`

The problem here is that 1-page chapters are not marked as read when this happens.
This will happen with `onChapterLeft()` in `ReaderPresenter.kt` but only after the previous function was called, thus I made a simple fix which checks if the read chapter was only 1 page in size and uses this for the chapter number.

There might be a better solution if `onChapterLeft()` would be called before `onBackPressed()` (or `getMangaSyncChapterToUpdate()` in particular). Maybe `onChapterLeft()` could be called from within `onBackPressed()` instead of in `onDestroy()` (`ReaderPresenter.kt`) where I think it's currently called from.