### PR TITLE
Download manager rewrite

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     compile 'com.evernote:android-job:1.1.3'
     compile 'com.google.android.gms:play-services-gcm:9.8.0'
 
-    compile 'com.github.seven332:unifile:0.1.4'
+    compile 'com.github.seven332:unifile:0.2.0'
 
     // ReactiveX
     compile 'io.reactivex:rxandroid:1.2.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 25
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        versionCode 13
+        versionCode 14
         versionName "0.3.2"
 
         buildConfigField "String", "COMMIT_COUNT", "\"${getCommitCount()}\""

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,7 +99,6 @@ dependencies {
 
     // Modified dependencies
     compile 'com.github.inorichi:subsampling-scale-image-view:96d2c7f'
-    compile 'com.github.inorichi:ReactiveNetwork:69092ed'
 
     // Android support library
     final support_library_version = '25.0.0'
@@ -122,11 +121,13 @@ dependencies {
     // ReactiveX
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.2.2'
+    compile 'com.jakewharton.rxrelay:rxrelay:1.2.0'
     compile 'com.f2prateek.rx.preferences:rx-preferences:1.0.2'
 
     // Network client
     compile "com.squareup.okhttp3:okhttp:3.4.2"
     compile 'com.squareup.okio:okio:1.11.0'
+    compile 'com.github.pwittchen:reactivenetwork:0.6.0'
 
     // REST
     final retrofit_version = '2.1.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,6 +117,8 @@ dependencies {
     compile 'com.evernote:android-job:1.1.3'
     compile 'com.google.android.gms:play-services-gcm:9.8.0'
 
+    compile 'com.github.seven332:unifile:0.1.4'
+
     // ReactiveX
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'io.reactivex:rxjava:1.2.2'

--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
@@ -168,11 +168,11 @@ class ChapterCache(private val context: Context) {
      * @param imageUrl url of image.
      * @return path of image.
      */
-    fun getImagePath(imageUrl: String): String? {
+    fun getImagePath(imageUrl: String): File? {
         try {
             // Get file from md5 key.
             val imageName = DiskUtils.hashKeyForDisk(imageUrl) + ".0"
-            return File(diskCache.directory, imageName).canonicalPath
+            return File(diskCache.directory, imageName)
         } catch (e: IOException) {
             return null
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/ChapterQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/ChapterQueries.kt
@@ -33,6 +33,15 @@ interface ChapterQueries : DbProvider {
             .withGetResolver(MangaChapterGetResolver.INSTANCE)
             .prepare()
 
+    fun getChapter(id: Long) = db.get()
+            .`object`(Chapter::class.java)
+            .withQuery(Query.builder()
+                    .table(ChapterTable.TABLE)
+                    .where("${ChapterTable.COL_ID} = ?")
+                    .whereArgs(id)
+                    .build())
+            .prepare()
+
     fun insertChapter(chapter: Chapter) = db.put().`object`(chapter).prepare()
 
     fun insertChapters(chapters: List<Chapter>) = db.put().objects(chapters).prepare()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -12,11 +12,13 @@ import rx.subjects.BehaviorSubject
 
 class DownloadManager(context: Context) {
 
-    val queue = DownloadQueue()
 
     private val provider = DownloadProvider(context)
 
-    private val downloader = Downloader(context, queue, provider)
+    private val downloader = Downloader(context, provider)
+
+    val queue: DownloadQueue
+        get() = downloader.queue
 
     val isRunning: Boolean
         get() = downloader.isRunning
@@ -37,7 +39,7 @@ class DownloadManager(context: Context) {
     }
 
     fun downloadChapters(manga: Manga, chapters: List<Chapter>) {
-        downloader.downloadChapters(manga, chapters)
+        downloader.queueChapters(manga, chapters)
     }
 
     private fun buildPageList(chapterDir: UniFile?): Observable<List<Page>> {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -227,7 +227,7 @@ class DownloadManager(
         return pageObservable
                 // When the image is ready, set image path, progress (just in case) and status
                 .doOnNext { file ->
-                    page.imagePath = file.uri.toString()
+                    page.imagePath = file.uri
                     page.progress = 100
                     download.downloadedImages++
                     page.status = Page.READY
@@ -278,8 +278,8 @@ class DownloadManager(
             val pages = mutableListOf<Page>()
             chapterDir.listFiles()
                     ?.filter { it.type?.startsWith("image") ?: false }
-                    ?.forEach {
-                        val page = Page(pages.size, imagePath = it.uri.toString())
+                    ?.forEach { file ->
+                        val page = Page(pages.size, imagePath = file.uri)
                         pages.add(page)
                         page.status = Page.READY
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -227,7 +227,7 @@ class DownloadManager(
         return pageObservable
                 // When the image is ready, set image path, progress (just in case) and status
                 .doOnNext { file ->
-                    page.imagePath = file.uri
+                    page.uri = file.uri
                     page.progress = 100
                     download.downloadedImages++
                     page.status = Page.READY
@@ -279,7 +279,7 @@ class DownloadManager(
             chapterDir.listFiles()
                     ?.filter { it.type?.startsWith("image") ?: false }
                     ?.forEach { file ->
-                        val page = Page(pages.size, imagePath = file.uri)
+                        val page = Page(pages.size, uri = file.uri)
                         pages.add(page)
                         page.status = Page.READY
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -1,282 +1,49 @@
 package eu.kanade.tachiyomi.data.download
 
 import android.content.Context
-import android.webkit.MimeTypeMap
 import com.hippo.unifile.UniFile
-import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
-import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.download.model.DownloadQueue
-import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.source.Source
-import eu.kanade.tachiyomi.data.source.SourceManager
 import eu.kanade.tachiyomi.data.source.model.Page
-import eu.kanade.tachiyomi.data.source.online.OnlineSource
-import eu.kanade.tachiyomi.util.DynamicConcurrentMergeOperator
-import eu.kanade.tachiyomi.util.RetryWithDelay
-import eu.kanade.tachiyomi.util.saveTo
-import okhttp3.Response
 import rx.Observable
-import rx.Subscription
-import rx.android.schedulers.AndroidSchedulers
-import rx.schedulers.Schedulers
 import rx.subjects.BehaviorSubject
-import rx.subjects.PublishSubject
-import timber.log.Timber
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
-import java.util.*
 
-class DownloadManager(
-        private val context: Context,
-        private val sourceManager: SourceManager = Injekt.get(),
-        private val preferences: PreferencesHelper = Injekt.get()
-) {
-
-    private val provider = DownloadProvider(context)
-
-    private val downloadsQueueSubject = PublishSubject.create<List<Download>>()
-    val runningSubject = BehaviorSubject.create<Boolean>()
-    private var downloadsSubscription: Subscription? = null
-
-    val downloadNotifier by lazy { DownloadNotifier(context) }
-
-    private val threadsSubject = BehaviorSubject.create<Int>()
-    private var threadsSubscription: Subscription? = null
+class DownloadManager(context: Context) {
 
     val queue = DownloadQueue()
 
-    @Volatile var isRunning: Boolean = false
-        private set
+    private val provider = DownloadProvider(context)
 
-    private fun initializeSubscriptions() {
-        if (isRunning) return
-        isRunning = true
+    private val downloader = Downloader(context, queue, provider)
 
-        downloadsSubscription?.unsubscribe()
+    val isRunning: Boolean
+        get() = downloader.isRunning
 
-        threadsSubscription = preferences.downloadThreads().asObservable()
-                .subscribe {
-                    threadsSubject.onNext(it)
-                    downloadNotifier.multipleDownloadThreads = it > 1
-                }
+    val runningSubject: BehaviorSubject<Boolean>
+        get() = downloader.runningSubject
 
-        downloadsSubscription = downloadsQueueSubject.flatMap { Observable.from(it) }
-                .lift(DynamicConcurrentMergeOperator<Download, Download>({ downloadChapter(it) }, threadsSubject))
-                .onBackpressureBuffer()
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    // Delete successful downloads from queue
-                    if (it.status == Download.DOWNLOADED) {
-                        // remove downloaded chapter from queue
-                        queue.del(it)
-                        downloadNotifier.onProgressChange(queue)
-                    }
-                    if (areAllDownloadsFinished()) {
-                        DownloadService.stop(context)
-                    }
-                }, { error ->
-                    DownloadService.stop(context)
-                    Timber.e(error)
-                    downloadNotifier.onError(error.message)
-                })
-
-        runningSubject.onNext(true)
+    internal fun startDownloads(): Boolean {
+        return downloader.start()
     }
 
-    private fun destroySubscriptions() {
-        if (!isRunning) return
-        isRunning = false
-        runningSubject.onNext(false)
-
-        downloadsSubscription?.unsubscribe()
-        downloadsSubscription = null
-
-        threadsSubscription?.unsubscribe()
-        threadsSubscription = null
+    internal fun stopDownloads(errorMessage: String? = null) {
+        downloader.stop(errorMessage)
     }
 
-    // Create a download object for every chapter and add them to the downloads queue
+    fun clearQueue() {
+        downloader.clearQueue()
+    }
+
     fun downloadChapters(manga: Manga, chapters: List<Chapter>) {
-        val source = sourceManager.get(manga.source) as? OnlineSource ?: return
-
-        // Add chapters to queue from the start
-        val sortedChapters = chapters.sortedByDescending { it.source_order }
-
-        // Used to avoid downloading chapters with the same name
-        val addedChapters = ArrayList<String>()
-        val pending = ArrayList<Download>()
-
-        for (chapter in sortedChapters) {
-            if (addedChapters.contains(chapter.name))
-                continue
-
-            addedChapters.add(chapter.name)
-            val download = Download(source, manga, chapter)
-
-            if (!prepareDownload(download)) {
-                queue.add(download)
-                pending.add(download)
-            }
-        }
-
-        // Initialize queue size
-        downloadNotifier.initialQueueSize = queue.size
-        // Show notification
-        downloadNotifier.onProgressChange(queue)
-
-        if (isRunning) downloadsQueueSubject.onNext(pending)
+        downloader.downloadChapters(manga, chapters)
     }
 
-    // Public method to check if a chapter is downloaded
-    fun isChapterDownloaded(source: Source, manga: Manga, chapter: Chapter): Boolean {
-        val mangaDir = provider.getMangaDir(source, manga)
-        return provider.getChapterDir(mangaDir, chapter).exists()
-    }
-
-    // Prepare the download. Returns true if the chapter is already downloaded
-    private fun prepareDownload(download: Download): Boolean {
-        // If the chapter is already queued, don't add it again
-        for (queuedDownload in queue) {
-            if (download.chapter.id == queuedDownload.chapter.id)
-                return true
-        }
-
-        val mangaDir = provider.getMangaDir(download.source, download.manga)
-        val filename = provider.getChapterDirName(download.chapter)
-        val chapterDir = mangaDir.subFile(filename)!!
-
-        if (chapterDir.exists())
-            return true
-
-        download.directory = chapterDir
-        download.filename = filename
-        return false
-    }
-
-    // Download the entire chapter
-    private fun downloadChapter(download: Download): Observable<Download> {
-        val tmpDir = download.directory.parentFile!!.subFile("${download.filename}_tmp")!!
-
-        val pageListObservable: Observable<List<Page>> = if (download.pages == null)
-            // Pull page list from network and add them to download object
-            download.source.fetchPageListFromNetwork(download.chapter)
-                    .doOnNext { pages ->
-                        download.pages = pages
-                    }
-        else
-            // Or if the page list already exists, start from the file
-            Observable.just(download.pages)
-
-        return Observable.defer {
-            pageListObservable
-                    .doOnNext { pages ->
-                        tmpDir.ensureDir()
-
-                        // Delete all temporary files
-                        tmpDir.listFiles()
-                                ?.filter { it.name!!.endsWith(".tmp") }
-                                ?.forEach { it.delete() }
-
-                        download.downloadedImages = 0
-                        download.status = Download.DOWNLOADING
-                    }
-                    // Get all the URLs to the source images, fetch pages if necessary
-                    .flatMap { download.source.fetchAllImageUrlsFromPageList(it) }
-                    // Start downloading images, consider we can have downloaded images already
-                    .concatMap { page -> getOrDownloadImage(page, download, tmpDir) }
-                    // Do when page is downloaded.
-                    .doOnNext {
-                        downloadNotifier.onProgressChange(download, queue)
-                    }
-                    // Do after download completes
-                    .doOnCompleted { onDownloadCompleted(download, tmpDir) }
-                    .toList()
-                    .map { pages -> download }
-                    // If the page list threw, it will resume here
-                    .onErrorReturn { error ->
-                        download.status = Download.ERROR
-                        downloadNotifier.onError(error.message, download.chapter.name)
-                        download
-                    }
-        }.subscribeOn(Schedulers.io())
-    }
-
-    // Get the image from the filesystem if it exists or download from network
-    private fun getOrDownloadImage(page: Page, download: Download, tmpDir: UniFile): Observable<Page> {
-        // If the image URL is empty, do nothing
-        if (page.imageUrl == null)
-            return Observable.just(page)
-
-        val filename = String.format("%03d", page.pageNumber + 1)
-        val tmpFile = tmpDir.findFile("$filename.tmp")
-
-        // Delete temp file if it exists.
-        tmpFile?.delete()
-
-        // Try to find the image file.
-        val imageFile = tmpDir.listFiles()!!.find { it.name!!.startsWith("$filename.")}
-
-        // If the image is already downloaded, do nothing. Otherwise download from network
-        val pageObservable = if (imageFile != null)
-            Observable.just(imageFile)
-        else
-            downloadImage(page, download.source, tmpDir, filename)
-
-        return pageObservable
-                // When the image is ready, set image path, progress (just in case) and status
-                .doOnNext { file ->
-                    page.uri = file.uri
-                    page.progress = 100
-                    download.downloadedImages++
-                    page.status = Page.READY
-                }
-                .map { page }
-                // Mark this page as error and allow to download the remaining
-                .onErrorReturn {
-                    page.progress = 0
-                    page.status = Page.ERROR
-                    page
-                }
-    }
-
-    // Save image on disk
-    private fun downloadImage(page: Page, source: OnlineSource, tmpDir: UniFile, filename: String): Observable<UniFile> {
-        page.status = Page.DOWNLOAD_IMAGE
-        page.progress = 0
-        return source.imageResponse(page)
-                .map { response ->
-                    val file = tmpDir.createFile("$filename.tmp")
-                    try {
-                        response.body().source().saveTo(file.openOutputStream())
-                        val extension = getFileExtension(response, file)
-                        file.renameTo("$filename.$extension")
-                    } catch (e: Exception) {
-                        response.close()
-                        file.delete()
-                        throw e
-                    }
-                    file
-                }
-                // Retry 3 times, waiting 2, 4 and 8 seconds between attempts.
-                .retryWhen(RetryWithDelay(3, { (2 shl it - 1) * 1000 }, Schedulers.trampoline()))
-    }
-
-    private fun getFileExtension(response: Response, file: UniFile): String? {
-        val contentType = response.body().contentType()
-        val mimeStr = if (contentType != null) {
-            "${contentType.type()}/${contentType.subtype()}"
-        } else {
-            context.contentResolver.getType(file.uri)
-        }
-        return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeStr)
-    }
-
-    fun buildPageList(chapterDir: UniFile): Observable<List<Page>> {
+    private fun buildPageList(chapterDir: UniFile?): Observable<List<Page>> {
         return Observable.fromCallable {
             val pages = mutableListOf<Page>()
-            chapterDir.listFiles()
+            chapterDir?.listFiles()
                     ?.filter { it.type?.startsWith("image") ?: false }
                     ?.forEach { file ->
                         val page = Page(pages.size, uri = file.uri)
@@ -288,91 +55,23 @@ class DownloadManager(
     }
 
     fun buildPageList(source: Source, manga: Manga, chapter: Chapter): Observable<List<Page>> {
-        val mangaDir = provider.getMangaDir(source, manga)
-        return buildPageList(provider.getChapterDir(mangaDir, chapter))
+        return buildPageList(provider.findChapterDir(source, manga, chapter))
     }
 
-    // Called when a download finishes. This doesn't mean the download was successful, so we check it
-    private fun onDownloadCompleted(download: Download, tmpDir: UniFile) {
-        var actualProgress = 0
-        var status = Download.DOWNLOADED
-
-        // If any page has an error, the download result will be error
-        for (page in download.pages!!) {
-            actualProgress += page.progress
-            if (page.status != Page.READY) {
-                status = Download.ERROR
-                downloadNotifier.onError(context.getString(R.string.download_notifier_page_ready_error), download.chapter.name)
-            }
-        }
-        // Ensure that the chapter folder has all the images
-        val downloadedImages = tmpDir.listFiles()!!.filterNot { it.name!!.endsWith(".tmp") }
-        if (downloadedImages.size < download.pages!!.size) {
-            status = Download.ERROR
-            downloadNotifier.onError(context.getString(R.string.download_notifier_page_error), download.chapter.name)
-        }
-
-        if (status == Download.DOWNLOADED) {
-            tmpDir.renameTo(download.filename)
-        }
-
-        download.totalProgress = actualProgress
-        download.status = status
+    fun getChapterDirName(chapter: Chapter): String {
+        return provider.getChapterDirName(chapter)
     }
 
-    fun getMangaDir(source: Source, manga: Manga): UniFile {
-        return provider.getMangaDir(source, manga)
+    fun findMangaDir(source: Source, manga: Manga): UniFile? {
+        return provider.findMangaDir(source, manga)
     }
 
-    fun getChapterDir(source: Source, manga: Manga, chapter: Chapter): UniFile {
-        val mangaDir = provider.getMangaDir(source, manga)
-        return provider.getChapterDir(mangaDir, chapter)
+    fun findChapterDir(source: Source, manga: Manga, chapter: Chapter): UniFile? {
+        return provider.findChapterDir(source, manga, chapter)
     }
 
     fun deleteChapter(source: Source, manga: Manga, chapter: Chapter) {
-        getChapterDir(source, manga, chapter).delete()
-    }
-
-    fun areAllDownloadsFinished(): Boolean {
-        for (download in queue) {
-            if (download.status <= Download.DOWNLOADING)
-                return false
-        }
-        return true
-    }
-
-    fun startDownloads(): Boolean {
-        if (queue.isEmpty())
-            return false
-
-        if (downloadsSubscription == null || downloadsSubscription!!.isUnsubscribed)
-            initializeSubscriptions()
-
-        val pending = ArrayList<Download>()
-        for (download in queue) {
-            if (download.status != Download.DOWNLOADED) {
-                if (download.status != Download.QUEUE) download.status = Download.QUEUE
-                pending.add(download)
-            }
-        }
-        downloadsQueueSubject.onNext(pending)
-
-        return !pending.isEmpty()
-    }
-
-    fun stopDownloads(errorMessage: String? = null) {
-        destroySubscriptions()
-        for (download in queue) {
-            if (download.status == Download.DOWNLOADING) {
-                download.status = Download.ERROR
-            }
-        }
-        errorMessage?.let { downloadNotifier.onError(it) }
-    }
-
-    fun clearQueue() {
-        queue.clear()
-        downloadNotifier.onClear()
+        provider.findChapterDir(source, manga, chapter)?.delete()
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -1,22 +1,22 @@
 package eu.kanade.tachiyomi.data.download
 
 import android.content.Context
-import android.net.Uri
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
-import com.google.gson.stream.JsonReader
+import android.webkit.MimeTypeMap
+import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.download.model.DownloadQueue
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
-import eu.kanade.tachiyomi.data.preference.getOrDefault
 import eu.kanade.tachiyomi.data.source.Source
 import eu.kanade.tachiyomi.data.source.SourceManager
 import eu.kanade.tachiyomi.data.source.model.Page
 import eu.kanade.tachiyomi.data.source.online.OnlineSource
-import eu.kanade.tachiyomi.util.*
+import eu.kanade.tachiyomi.util.DynamicConcurrentMergeOperator
+import eu.kanade.tachiyomi.util.RetryWithDelay
+import eu.kanade.tachiyomi.util.saveTo
+import okhttp3.Response
 import rx.Observable
 import rx.Subscription
 import rx.android.schedulers.AndroidSchedulers
@@ -26,8 +26,6 @@ import rx.subjects.PublishSubject
 import timber.log.Timber
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.io.File
-import java.io.FileReader
 import java.util.*
 
 class DownloadManager(
@@ -36,7 +34,7 @@ class DownloadManager(
         private val preferences: PreferencesHelper = Injekt.get()
 ) {
 
-    private val gson = Gson()
+    private val provider = DownloadProvider(context)
 
     private val downloadsQueueSubject = PublishSubject.create<List<Download>>()
     val runningSubject = BehaviorSubject.create<Boolean>()
@@ -49,14 +47,12 @@ class DownloadManager(
 
     val queue = DownloadQueue()
 
-    val imageFilenameRegex = "[^\\sa-zA-Z0-9.-]".toRegex()
-
-    val PAGE_LIST_FILE = "index.json"
-
     @Volatile var isRunning: Boolean = false
         private set
 
     private fun initializeSubscriptions() {
+        if (isRunning) return
+        isRunning = true
 
         downloadsSubscription?.unsubscribe()
 
@@ -86,27 +82,19 @@ class DownloadManager(
                     downloadNotifier.onError(error.message)
                 })
 
-        if (!isRunning) {
-            isRunning = true
-            runningSubject.onNext(true)
-        }
+        runningSubject.onNext(true)
     }
 
-    fun destroySubscriptions() {
-        if (isRunning) {
-            isRunning = false
-            runningSubject.onNext(false)
-        }
+    private fun destroySubscriptions() {
+        if (!isRunning) return
+        isRunning = false
+        runningSubject.onNext(false)
 
-        if (downloadsSubscription != null) {
-            downloadsSubscription?.unsubscribe()
-            downloadsSubscription = null
-        }
+        downloadsSubscription?.unsubscribe()
+        downloadsSubscription = null
 
-        if (threadsSubscription != null) {
-            threadsSubscription?.unsubscribe()
-        }
-
+        threadsSubscription?.unsubscribe()
+        threadsSubscription = null
     }
 
     // Create a download object for every chapter and add them to the downloads queue
@@ -143,12 +131,8 @@ class DownloadManager(
 
     // Public method to check if a chapter is downloaded
     fun isChapterDownloaded(source: Source, manga: Manga, chapter: Chapter): Boolean {
-        val directory = getAbsoluteChapterDirectory(source, manga, chapter)
-        if (!directory.exists())
-            return false
-
-        val pages = getSavedPageList(source, manga, chapter)
-        return isChapterDownloaded(directory, pages)
+        val mangaDir = provider.getMangaDir(source, manga)
+        return provider.getChapterDir(mangaDir, chapter).exists()
     }
 
     // Prepare the download. Returns true if the chapter is already downloaded
@@ -159,170 +143,158 @@ class DownloadManager(
                 return true
         }
 
-        // Add the directory to the download object for future access
-        download.directory = getAbsoluteChapterDirectory(download)
+        val mangaDir = provider.getMangaDir(download.source, download.manga)
+        val chapterDir = provider.getChapterDir(mangaDir, download.chapter)
 
-        // If the directory doesn't exist, the chapter isn't downloaded.
-        if (!download.directory.exists()) {
-            return false
-        }
+        if (chapterDir.exists())
+            return true
 
-        // If the page list doesn't exist, the chapter isn't downloaded
-        val savedPages = getSavedPageList(download) ?: return false
-
-        // Add the page list to the download object for future access
-        download.pages = savedPages
-
-        // If the number of files matches the number of pages, the chapter is downloaded.
-        // We have the index file, so we check one file more
-        return isChapterDownloaded(download.directory, download.pages)
-    }
-
-    // Check that all the images are downloaded
-    private fun isChapterDownloaded(directory: File, pages: List<Page>?): Boolean {
-        return pages != null && !pages.isEmpty() && pages.size + 1 == directory.listFiles().size
+        download.directory = chapterDir
+        return false
     }
 
     // Download the entire chapter
     private fun downloadChapter(download: Download): Observable<Download> {
-        DiskUtils.createDirectory(download.directory)
+        val tmpDir = provider.getTmpChapterDir(download.directory)
 
         val pageListObservable: Observable<List<Page>> = if (download.pages == null)
             // Pull page list from network and add them to download object
             download.source.fetchPageListFromNetwork(download.chapter)
                     .doOnNext { pages ->
                         download.pages = pages
-                        savePageList(download)
                     }
         else
-        // Or if the page list already exists, start from the file
+            // Or if the page list already exists, start from the file
             Observable.just(download.pages)
 
         return Observable.defer {
             pageListObservable
                     .doOnNext { pages ->
+                        tmpDir.ensureDir()
+
+                        // Delete all temporary files
+                        tmpDir.listFiles()
+                                ?.filter { it.name!!.endsWith(".tmp") }
+                                ?.forEach { it.delete() }
+
                         download.downloadedImages = 0
                         download.status = Download.DOWNLOADING
                     }
                     // Get all the URLs to the source images, fetch pages if necessary
                     .flatMap { download.source.fetchAllImageUrlsFromPageList(it) }
                     // Start downloading images, consider we can have downloaded images already
-                    .concatMap { page -> getOrDownloadImage(page, download) }
+                    .concatMap { page -> getOrDownloadImage(page, download, tmpDir) }
                     // Do when page is downloaded.
                     .doOnNext {
                         downloadNotifier.onProgressChange(download, queue)
                     }
                     // Do after download completes
-                    .doOnCompleted { onDownloadCompleted(download) }
+                    .doOnCompleted { onDownloadCompleted(download, tmpDir) }
                     .toList()
                     .map { pages -> download }
                     // If the page list threw, it will resume here
-                    .onErrorResumeNext { error ->
+                    .onErrorReturn { error ->
                         download.status = Download.ERROR
                         downloadNotifier.onError(error.message, download.chapter.name)
-                        Observable.just(download)
+                        download
                     }
         }.subscribeOn(Schedulers.io())
     }
 
     // Get the image from the filesystem if it exists or download from network
-    private fun getOrDownloadImage(page: Page, download: Download): Observable<Page> {
+    private fun getOrDownloadImage(page: Page, download: Download, tmpDir: UniFile): Observable<Page> {
         // If the image URL is empty, do nothing
         if (page.imageUrl == null)
             return Observable.just(page)
 
-        val filename = getImageFilename(page)
-        val imagePath = File(download.directory, filename)
+        val filename = String.format("%03d", page.pageNumber + 1)
+        val tmpFile = tmpDir.findFile("$filename.tmp")
+
+        // Delete temp file if it exists.
+        tmpFile?.delete()
+
+        // Try to find the image file.
+        val imageFile = tmpDir.listFiles()!!.find { it.name!!.startsWith("$filename.")}
 
         // If the image is already downloaded, do nothing. Otherwise download from network
-        val pageObservable = if (isImageDownloaded(imagePath))
-            Observable.just(page)
+        val pageObservable = if (imageFile != null)
+            Observable.just(imageFile)
         else
-            downloadImage(page, download.source, download.directory, filename)
+            downloadImage(page, download.source, tmpDir, filename)
 
         return pageObservable
                 // When the image is ready, set image path, progress (just in case) and status
-                .doOnNext {
-                    page.imagePath = imagePath.absolutePath
+                .doOnNext { file ->
+                    page.imagePath = file.uri.toString()
                     page.progress = 100
                     download.downloadedImages++
                     page.status = Page.READY
                 }
+                .map { page }
                 // Mark this page as error and allow to download the remaining
-                .onErrorResumeNext {
+                .onErrorReturn {
                     page.progress = 0
                     page.status = Page.ERROR
-                    Observable.just(page)
+                    page
                 }
     }
 
     // Save image on disk
-    private fun downloadImage(page: Page, source: OnlineSource, directory: File, filename: String): Observable<Page> {
+    private fun downloadImage(page: Page, source: OnlineSource, tmpDir: UniFile, filename: String): Observable<UniFile> {
         page.status = Page.DOWNLOAD_IMAGE
+        page.progress = 0
         return source.imageResponse(page)
-                .map {
-                    val file = File(directory, filename)
+                .map { response ->
+                    val file = tmpDir.createFile("$filename.tmp")
                     try {
-                        file.parentFile.mkdirs()
-                        it.body().source().saveTo(file.outputStream())
+                        response.body().source().saveTo(file.openOutputStream())
+                        val extension = getFileExtension(response, file)
+                        file.renameTo("$filename.$extension")
                     } catch (e: Exception) {
-                        it.close()
+                        response.close()
                         file.delete()
                         throw e
                     }
-                    page
+                    file
                 }
                 // Retry 3 times, waiting 2, 4 and 8 seconds between attempts.
                 .retryWhen(RetryWithDelay(3, { (2 shl it - 1) * 1000 }, Schedulers.trampoline()))
     }
 
-    // Public method to get the image from the filesystem. It does NOT provide any way to download the image
-    fun getDownloadedImage(page: Page, chapterDir: File): Observable<Page> {
-        if (page.imageUrl == null) {
-            page.status = Page.ERROR
-            return Observable.just(page)
-        }
-
-        val imagePath = File(chapterDir, getImageFilename(page))
-
-        // When the image is ready, set image path, progress (just in case) and status
-        if (isImageDownloaded(imagePath)) {
-            page.imagePath = imagePath.absolutePath
-            page.progress = 100
-            page.status = Page.READY
+    private fun getFileExtension(response: Response, file: UniFile): String? {
+        val contentType = response.body().contentType()
+        val mimeStr = if (contentType != null) {
+            "${contentType.type()}/${contentType.subtype()}"
         } else {
-            page.status = Page.ERROR
+            context.contentResolver.getType(file.uri)
         }
-        return Observable.just(page)
+        return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeStr)
     }
 
-    // Get the filename for an image given the page
-    fun getImageFilename(page: Page): String {
-        val url = page.imageUrl
-        val number = String.format("%03d", page.pageNumber + 1)
-
-        // Try to preserve file extension
-        return when {
-            UrlUtil.isJpg(url) -> "$number.jpg"
-            UrlUtil.isPng(url) -> "$number.png"
-            UrlUtil.isGif(url) -> "$number.gif"
-            else -> Uri.parse(url).lastPathSegment.replace(imageFilenameRegex, "_")
+    fun buildPageList(chapterDir: UniFile): Observable<List<Page>> {
+        return Observable.fromCallable {
+            val pages = mutableListOf<Page>()
+            chapterDir.listFiles()
+                    ?.filterNot { it.name!!.endsWith(".tmp") }
+                    ?.forEach {
+                        val page = Page(pages.size, imagePath = it.uri.toString())
+                        pages.add(page)
+                        page.status = Page.READY
+                    }
+            pages
         }
     }
 
-    private fun isImageDownloaded(imagePath: File): Boolean {
-        return imagePath.exists()
+    fun buildPageList(source: Source, manga: Manga, chapter: Chapter): Observable<List<Page>> {
+        val mangaDir = provider.getMangaDir(source, manga)
+        return buildPageList(provider.getChapterDir(mangaDir, chapter))
     }
 
     // Called when a download finishes. This doesn't mean the download was successful, so we check it
-    private fun onDownloadCompleted(download: Download) {
-        checkDownloadIsSuccessful(download)
-        savePageList(download)
-    }
-
-    private fun checkDownloadIsSuccessful(download: Download) {
+    private fun onDownloadCompleted(download: Download, tmpDir: UniFile) {
         var actualProgress = 0
         var status = Download.DOWNLOADED
+
         // If any page has an error, the download result will be error
         for (page in download.pages!!) {
             actualProgress += page.progress
@@ -332,77 +304,31 @@ class DownloadManager(
             }
         }
         // Ensure that the chapter folder has all the images
-        if (!isChapterDownloaded(download.directory, download.pages)) {
+        val downloadedImages = tmpDir.listFiles()!!.filterNot { it.name!!.endsWith(".tmp") }
+        if (downloadedImages.size < download.pages!!.size) {
             status = Download.ERROR
             downloadNotifier.onError(context.getString(R.string.download_notifier_page_error), download.chapter.name)
         }
+
+        if (status == Download.DOWNLOADED) {
+            tmpDir.renameTo(download.directory.name)
+        }
+
         download.totalProgress = actualProgress
         download.status = status
     }
 
-    // Return the page list from the chapter's directory if it exists, null otherwise
-    fun getSavedPageList(source: Source, manga: Manga, chapter: Chapter): List<Page>? {
-        val chapterDir = getAbsoluteChapterDirectory(source, manga, chapter)
-        val pagesFile = File(chapterDir, PAGE_LIST_FILE)
-
-        return try {
-            JsonReader(FileReader(pagesFile)).use {
-                val collectionType = object : TypeToken<List<Page>>() {}.type
-                gson.fromJson(it, collectionType)
-            }
-        } catch (e: Exception) {
-            null
-        }
+    fun getMangaDir(source: Source, manga: Manga): UniFile {
+        return provider.getMangaDir(source, manga)
     }
 
-    // Shortcut for the method above
-    private fun getSavedPageList(download: Download): List<Page>? {
-        return getSavedPageList(download.source, download.manga, download.chapter)
-    }
-
-    // Save the page list to the chapter's directory
-    fun savePageList(source: Source, manga: Manga, chapter: Chapter, pages: List<Page>) {
-        val chapterDir = getAbsoluteChapterDirectory(source, manga, chapter)
-        val pagesFile = File(chapterDir, PAGE_LIST_FILE)
-
-        pagesFile.outputStream().use {
-            try {
-                it.write(gson.toJson(pages).toByteArray())
-                it.flush()
-            } catch (error: Exception) {
-                Timber.e(error)
-            }
-        }
-    }
-
-    // Shortcut for the method above
-    private fun savePageList(download: Download) {
-        savePageList(download.source, download.manga, download.chapter, download.pages!!)
-    }
-
-    fun getAbsoluteMangaDirectory(source: Source, manga: Manga): File {
-        val mangaRelativePath = source.toString() +
-                File.separator +
-                manga.title.replace("[^\\sa-zA-Z0-9.-]".toRegex(), "_")
-
-        return File(preferences.downloadsDirectory().getOrDefault(), mangaRelativePath)
-    }
-
-    // Get the absolute path to the chapter directory
-    fun getAbsoluteChapterDirectory(source: Source, manga: Manga, chapter: Chapter): File {
-        val chapterRelativePath = chapter.name.replace("[^\\sa-zA-Z0-9.-]".toRegex(), "_")
-
-        return File(getAbsoluteMangaDirectory(source, manga), chapterRelativePath)
-    }
-
-    // Shortcut for the method above
-    private fun getAbsoluteChapterDirectory(download: Download): File {
-        return getAbsoluteChapterDirectory(download.source, download.manga, download.chapter)
+    fun getChapterDir(source: Source, manga: Manga, chapter: Chapter): UniFile {
+        val mangaDir = provider.getMangaDir(source, manga)
+        return provider.getChapterDir(mangaDir, chapter)
     }
 
     fun deleteChapter(source: Source, manga: Manga, chapter: Chapter) {
-        val path = getAbsoluteChapterDirectory(source, manga, chapter)
-        DiskUtils.deleteFiles(path)
+        getChapterDir(source, manga, chapter).delete()
     }
 
     fun areAllDownloadsFinished(): Boolean {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -10,38 +10,96 @@ import eu.kanade.tachiyomi.data.source.model.Page
 import rx.Observable
 import rx.subjects.BehaviorSubject
 
+/**
+ * This class is used to manage chapter downloads in the application. It must be instantiated once
+ * and retrieved through dependency injection. You can use this class to queue new chapters or query
+ * downloaded chapters.
+ *
+ * @param context the application context.
+ */
 class DownloadManager(context: Context) {
 
-
+    /**
+     * Downloads provider, used to retrieve the folders where the chapters are or should be stored.
+     */
     private val provider = DownloadProvider(context)
 
+    /**
+     * Downloader whose only task is to download chapters.
+     */
     private val downloader = Downloader(context, provider)
 
+    /**
+     * Downloads queue, where the pending chapters are stored.
+     */
     val queue: DownloadQueue
         get() = downloader.queue
 
+    /**
+     * Whether the downloader is running.
+     */
     val isRunning: Boolean
         get() = downloader.isRunning
 
+    /**
+     * Subject for subscribing to downloader status.
+     */
     val runningSubject: BehaviorSubject<Boolean>
         get() = downloader.runningSubject
 
-    internal fun startDownloads(): Boolean {
+    /**
+     * Tells the downloader to begin downloads.
+     *
+     * @return true if it's started, false otherwise (empty queue).
+     */
+    fun startDownloads(): Boolean {
         return downloader.start()
     }
 
-    internal fun stopDownloads(errorMessage: String? = null) {
-        downloader.stop(errorMessage)
+    /**
+     * Tells the downloader to stop downloads.
+     *
+     * @param reason an optional reason for being stopped, used to notify the user.
+     */
+    fun stopDownloads(reason: String? = null) {
+        downloader.stop(reason)
     }
 
+    /**
+     * Empties the download queue.
+     */
     fun clearQueue() {
         downloader.clearQueue()
     }
 
+    /**
+     * Tells the downloader to enqueue the given list of chapters.
+     *
+     * @param manga the manga of the chapters.
+     * @param chapters the list of chapters to enqueue.
+     */
     fun downloadChapters(manga: Manga, chapters: List<Chapter>) {
         downloader.queueChapters(manga, chapters)
     }
 
+    /**
+     * Builds the page list of a downloaded chapter.
+     *
+     * @param source the source of the chapter.
+     * @param manga the manga of the chapter.
+     * @param chapter the downloaded chapter.
+     * @return an observable containing the list of pages from the chapter.
+     */
+    fun buildPageList(source: Source, manga: Manga, chapter: Chapter): Observable<List<Page>> {
+        return buildPageList(provider.findChapterDir(source, manga, chapter))
+    }
+
+    /**
+     * Builds the page list of a downloaded chapter.
+     *
+     * @param chapterDir the file where the chapter is downloaded.
+     * @return an observable containing the list of pages from the chapter.
+     */
     private fun buildPageList(chapterDir: UniFile?): Observable<List<Page>> {
         return Observable.fromCallable {
             val pages = mutableListOf<Page>()
@@ -56,22 +114,43 @@ class DownloadManager(context: Context) {
         }
     }
 
-    fun buildPageList(source: Source, manga: Manga, chapter: Chapter): Observable<List<Page>> {
-        return buildPageList(provider.findChapterDir(source, manga, chapter))
-    }
-
+    /**
+     * Returns the directory name for the given chapter.
+     *
+     * @param chapter the chapter to query.
+     */
     fun getChapterDirName(chapter: Chapter): String {
         return provider.getChapterDirName(chapter)
     }
 
+    /**
+     * Returns the directory for the given manga, if it exists.
+     *
+     * @param source the source of the manga.
+     * @param manga the manga to query.
+     */
     fun findMangaDir(source: Source, manga: Manga): UniFile? {
         return provider.findMangaDir(source, manga)
     }
 
+    /**
+     * Returns the directory for the given chapter, if it exists.
+     *
+     * @param source the source of the chapter.
+     * @param manga the manga of the chapter.
+     * @param chapter the chapter to query.
+     */
     fun findChapterDir(source: Source, manga: Manga, chapter: Chapter): UniFile? {
         return provider.findChapterDir(source, manga, chapter)
     }
 
+    /**
+     * Deletes the directory of a downloaded chapter.
+     *
+     * @param source the source of the chapter.
+     * @param manga the manga of the chapter.
+     * @param chapter the chapter to delete.
+     */
     fun deleteChapter(source: Source, manga: Manga, chapter: Chapter) {
         provider.findChapterDir(source, manga, chapter)?.delete()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -36,12 +36,6 @@ class DownloadManager(context: Context) {
         get() = downloader.queue
 
     /**
-     * Whether the downloader is running.
-     */
-    val isRunning: Boolean
-        get() = downloader.isRunning
-
-    /**
      * Subject for subscribing to downloader status.
      */
     val runningRelay: BehaviorRelay<Boolean>

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -2,13 +2,13 @@ package eu.kanade.tachiyomi.data.download
 
 import android.content.Context
 import com.hippo.unifile.UniFile
+import com.jakewharton.rxrelay.BehaviorRelay
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.model.DownloadQueue
 import eu.kanade.tachiyomi.data.source.Source
 import eu.kanade.tachiyomi.data.source.model.Page
 import rx.Observable
-import rx.subjects.BehaviorSubject
 
 /**
  * This class is used to manage chapter downloads in the application. It must be instantiated once
@@ -44,8 +44,8 @@ class DownloadManager(context: Context) {
     /**
      * Subject for subscribing to downloader status.
      */
-    val runningSubject: BehaviorSubject<Boolean>
-        get() = downloader.runningSubject
+    val runningRelay: BehaviorRelay<Boolean>
+        get() = downloader.runningRelay
 
     /**
      * Tells the downloader to begin downloads.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
@@ -1,30 +1,27 @@
 package eu.kanade.tachiyomi.data.download
 
 import android.content.Context
+import android.graphics.BitmapFactory
 import android.support.v4.app.NotificationCompat
 import eu.kanade.tachiyomi.Constants
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.download.model.DownloadQueue
 import eu.kanade.tachiyomi.util.notificationManager
-import eu.kanade.tachiyomi.util.toast
 
 /**
  * DownloadNotifier is used to show notifications when downloading one or multiple chapters.
  *
  * @param context context of application
  */
-class DownloadNotifier(private val context: Context) {
+internal class DownloadNotifier(private val context: Context) {
     /**
      * Notification builder.
      */
-    private val notificationBuilder = NotificationCompat.Builder(context)
-
-    /**
-     * Id of the notification.
-     */
-    private val notificationId: Int
-        get() = Constants.NOTIFICATION_DOWNLOAD_CHAPTER_ID
+    private val notification by lazy {
+        NotificationCompat.Builder(context)
+                .setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
+    }
 
     /**
      * Status of download. Used for correct notification icon.
@@ -34,12 +31,29 @@ class DownloadNotifier(private val context: Context) {
     /**
      * The size of queue on start download.
      */
-    internal var initialQueueSize = 0
+    var initialQueueSize = 0
 
     /**
      * Simultaneous download setting > 1.
      */
-    internal var multipleDownloadThreads = false
+    var multipleDownloadThreads = false
+
+    /**
+     * Shows a notification from this builder.
+     *
+     * @param id the id of the notification.
+     */
+    private fun NotificationCompat.Builder.show(id: Int = Constants.NOTIFICATION_DOWNLOAD_CHAPTER_ID) {
+        context.notificationManager.notify(id, build())
+    }
+
+    /**
+     * Dismiss the downloader's notification. Downloader error notifications use a different id, so
+     * those can only be dismissed by the user.
+     */
+    fun dismiss() {
+        context.notificationManager.cancel(Constants.NOTIFICATION_DOWNLOAD_CHAPTER_ID)
+    }
 
     /**
      * Called when download progress changes.
@@ -47,45 +61,47 @@ class DownloadNotifier(private val context: Context) {
      *
      * @param queue the queue containing downloads.
      */
-    internal fun onProgressChange(queue: DownloadQueue) {
-        if (multipleDownloadThreads)
+    fun onProgressChange(queue: DownloadQueue) {
+        if (multipleDownloadThreads) {
             doOnProgressChange(null, queue)
+        }
     }
 
     /**
-     * Called when download progress changes
-     * Note: Only accepted when single download active
+     * Called when download progress changes.
+     * Note: Only accepted when single download active.
      *
-     * @param download download object containing download information
-     * @param queue the queue containing downloads
+     * @param download download object containing download information.
+     * @param queue the queue containing downloads.
      */
-    internal fun onProgressChange(download: Download, queue: DownloadQueue) {
-        if (!multipleDownloadThreads)
+    fun onProgressChange(download: Download, queue: DownloadQueue) {
+        if (!multipleDownloadThreads) {
             doOnProgressChange(download, queue)
+        }
     }
 
     /**
-     * Show notification progress of chapter
+     * Show notification progress of chapter.
      *
-     * @param download download object containing download information
-     * @param queue the queue containing downloads
+     * @param download download object containing download information.
+     * @param queue the queue containing downloads.
      */
     private fun doOnProgressChange(download: Download?, queue: DownloadQueue) {
         // Check if download is completed
         if (multipleDownloadThreads) {
             if (queue.isEmpty()) {
-                onComplete(null)
+                onChapterCompleted(null)
                 return
             }
         } else {
             if (download != null && download.pages!!.size == download.downloadedImages) {
-                onComplete(download)
+                onChapterCompleted(download)
                 return
             }
         }
 
         // Create notification
-        with(notificationBuilder) {
+        with(notification) {
             // Check if icon needs refresh
             if (!isDownloading) {
                 setSmallIcon(android.R.drawable.stat_sys_download)
@@ -117,17 +133,17 @@ class DownloadNotifier(private val context: Context) {
             }
         }
         // Displays the progress bar on notification
-        context.notificationManager.notify(notificationId, notificationBuilder.build())
+        notification.show()
     }
 
     /**
-     * Called when chapter is downloaded
+     * Called when chapter is downloaded.
      *
-     * @param download download object containing download information
+     * @param download download object containing download information.
      */
-    private fun onComplete(download: Download?) {
+    private fun onChapterCompleted(download: Download?) {
         // Create notification.
-        with(notificationBuilder) {
+        with(notification) {
             setContentTitle(download?.chapter?.name ?: context.getString(R.string.app_name))
             setContentText(context.getString(R.string.update_check_notification_download_complete))
             setSmallIcon(android.R.drawable.stat_sys_download_done)
@@ -135,7 +151,7 @@ class DownloadNotifier(private val context: Context) {
         }
 
         // Show notification.
-        context.notificationManager.notify(notificationId, notificationBuilder.build())
+        notification.show()
 
         // Reset initial values
         isDownloading = false
@@ -143,29 +159,38 @@ class DownloadNotifier(private val context: Context) {
     }
 
     /**
-     * Clears the notification message
+     * Called when the downloader receives a warning.
+     *
+     * @param reason the text to show.
      */
-    internal fun onClear() {
-        context.notificationManager.cancel(notificationId)
+    fun onWarning(reason: String) {
+        with(notification) {
+            setContentTitle(context.getString(R.string.download_notifier_downloader_title))
+            setContentText(reason)
+            setSmallIcon(android.R.drawable.stat_sys_warning)
+            setProgress(0, 0, false)
+        }
+        notification.show()
     }
 
     /**
-     * Called on error while downloading chapter
+     * Called when the downloader receives an error. It's shown as a separate notification to avoid
+     * being overwritten.
      *
-     * @param error string containing error information
-     * @param chapter string containing chapter title
+     * @param error string containing error information.
+     * @param chapter string containing chapter title.
      */
-    internal fun onError(error: String? = null, chapter: String? = null) {
+    fun onError(error: String? = null, chapter: String? = null) {
         // Create notification
-        with(notificationBuilder) {
-            setContentTitle(chapter ?: context.getString(R.string.download_notifier_title_error))
+        with(notification) {
+            setContentTitle(chapter ?: context.getString(R.string.download_notifier_downloader_title))
             setContentText(error ?: context.getString(R.string.download_notifier_unkown_error))
             setSmallIcon(android.R.drawable.stat_sys_warning)
             setProgress(0, 0, false)
         }
-        context.notificationManager.notify(Constants.NOTIFICATION_DOWNLOAD_CHAPTER_ERROR_ID, notificationBuilder.build())
+        notification.show(Constants.NOTIFICATION_DOWNLOAD_CHAPTER_ERROR_ID)
+
         // Reset download information
-        onClear()
         isDownloading = false
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.Constants
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.download.model.DownloadQueue
+import eu.kanade.tachiyomi.util.chop
 import eu.kanade.tachiyomi.util.notificationManager
 
 /**
@@ -120,11 +121,7 @@ internal class DownloadNotifier(private val context: Context) {
                 setProgress(initialQueueSize, initialQueueSize - queue.size, false)
             } else {
                 download?.let {
-                    if (it.chapter.name.length >= 33)
-                        setContentTitle(it.chapter.name.slice(IntRange(0, 30)).plus("..."))
-                    else
-                        setContentTitle(it.chapter.name)
-
+                    setContentTitle(it.chapter.name.chop(30))
                     setContentText(context.getString(R.string.chapter_downloading_progress)
                             .format(it.downloadedImages, it.pages!!.size))
                     setProgress(it.pages!!.size, it.downloadedImages, false)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -25,23 +25,17 @@ class DownloadProvider(private val context: Context) {
     }
 
     fun getMangaDir(source: Source, manga: Manga): UniFile {
-        val uri = downloadsDir.uri.buildUpon()
-                .appendPath(source.toString())
-                .appendPath(buildValidFatFilename(manga.title))
-                .build()
-        return UniFile.fromUri(context, uri)
+        return downloadsDir
+                .subFile(source.toString())!!
+                .subFile(buildValidFatFilename(manga.title))!!
     }
 
     fun getChapterDir(mangaDir: UniFile, chapter: Chapter): UniFile {
-        val uri = mangaDir.uri.buildUpon()
-                .appendPath(buildValidFatFilename(chapter.name))
-                .build()
-        return UniFile.fromUri(context, uri)
+        return mangaDir.subFile(getChapterDirName(chapter))!!
     }
 
-    fun getTmpChapterDir(chapterDir: UniFile): UniFile {
-        val file = chapterDir.uri.buildUpon().encodedPath("${chapterDir.uri.encodedPath}_tmp").build()
-        return UniFile.fromUri(context, file)
+    fun getChapterDirName(chapter: Chapter): String {
+        return buildValidFatFilename(chapter.name)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -26,12 +26,30 @@ class DownloadProvider(private val context: Context) {
 
     fun getMangaDir(source: Source, manga: Manga): UniFile {
         return downloadsDir
-                .subFile(source.toString())!!
-                .subFile(buildValidFatFilename(manga.title))!!
+                .subFile(getSourceDirName(source))!!
+                .subFile(getMangaDirName(manga))!!
     }
 
     fun getChapterDir(mangaDir: UniFile, chapter: Chapter): UniFile {
         return mangaDir.subFile(getChapterDirName(chapter))!!
+    }
+
+    fun findMangaDir(source: Source, manga: Manga): UniFile? {
+        val sourceDir = downloadsDir.findFile(getSourceDirName(source))
+        return sourceDir?.findFile(getMangaDirName(manga))
+    }
+
+    fun findChapterDir(source: Source, manga: Manga, chapter: Chapter): UniFile? {
+        val mangaDir = findMangaDir(source, manga)
+        return mangaDir?.findFile(getChapterDirName(chapter))
+    }
+
+    fun getSourceDirName(source: Source): String {
+        return source.toString()
+    }
+
+    fun getMangaDirName(manga: Manga): String {
+        return buildValidFatFilename(manga.title)
     }
 
     fun getChapterDirName(chapter: Chapter): String {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -1,0 +1,77 @@
+package eu.kanade.tachiyomi.data.download
+
+import android.content.Context
+import android.net.Uri
+import com.hippo.unifile.UniFile
+import eu.kanade.tachiyomi.data.database.models.Chapter
+import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.data.source.Source
+import uy.kohesive.injekt.injectLazy
+
+class DownloadProvider(private val context: Context) {
+
+    private val preferences: PreferencesHelper by injectLazy()
+
+    private lateinit var downloadsDir: UniFile
+
+    init {
+        preferences.downloadsDirectory().asObservable()
+                .subscribe { setDownloadsDir(it) }
+    }
+
+    private fun setDownloadsDir(path: String) {
+        downloadsDir = UniFile.fromUri(context, Uri.parse(path))
+    }
+
+    fun getMangaDir(source: Source, manga: Manga): UniFile {
+        val uri = downloadsDir.uri.buildUpon()
+                .appendPath(source.toString())
+                .appendPath(buildValidFatFilename(manga.title))
+                .build()
+        return UniFile.fromUri(context, uri)
+    }
+
+    fun getChapterDir(mangaDir: UniFile, chapter: Chapter): UniFile {
+        val uri = mangaDir.uri.buildUpon()
+                .appendPath(buildValidFatFilename(chapter.name))
+                .build()
+        return UniFile.fromUri(context, uri)
+    }
+
+    fun getTmpChapterDir(chapterDir: UniFile): UniFile {
+        val file = chapterDir.uri.buildUpon().encodedPath("${chapterDir.uri.encodedPath}_tmp").build()
+        return UniFile.fromUri(context, file)
+    }
+
+    /**
+     * Mutate the given filename to make it valid for a FAT filesystem,
+     * replacing any invalid characters with "_".
+     */
+    private fun buildValidFatFilename(name: String): String {
+        if (name.isNullOrBlank() || "." == name || ".." == name) {
+            return "(invalid)"
+        }
+        val res = StringBuilder(name.length)
+        name.forEach { c ->
+            if (isValidFatFilenameChar(c)) {
+                res.append(c)
+            } else {
+                res.append('_')
+            }
+        }
+        // Even though vfat allows 255 UCS-2 chars, we might eventually write to
+        // ext4 through a FUSE layer, so use that limit.
+        return res.toString().take(255)
+    }
+
+    private fun isValidFatFilenameChar(c: Char): Boolean {
+        if (0x00.toChar() <= c && c <= 0x1f.toChar()) {
+            return false
+        }
+        when (c) {
+            '"', '*', '/', ':', '<', '>', '?', '\\', '|', 0x7f.toChar() -> return false
+            else -> return true
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -9,51 +9,89 @@ import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.source.Source
 import uy.kohesive.injekt.injectLazy
 
+/**
+ * This class is used to provide the directories where the downloads should be saved.
+ * It uses the following path scheme: /<root downloads dir>/<source name>/<manga>/<chapter>
+ *
+ * @param context the application context.
+ */
 class DownloadProvider(private val context: Context) {
 
+    /**
+     * Preferences helper.
+     */
     private val preferences: PreferencesHelper by injectLazy()
 
+    /**
+     * The root directory for downloads.
+     */
     private lateinit var downloadsDir: UniFile
 
     init {
         preferences.downloadsDirectory().asObservable()
-                .subscribe { setDownloadsDir(it) }
+                .subscribe { downloadsDir = UniFile.fromUri(context, Uri.parse(it)) }
     }
 
-    private fun setDownloadsDir(path: String) {
-        downloadsDir = UniFile.fromUri(context, Uri.parse(path))
-    }
-
-    fun getMangaDir(source: Source, manga: Manga): UniFile {
+    /**
+     * Returns the download directory for a manga. For internal use only.
+     *
+     * @param source the source of the manga.
+     * @param manga the manga to query.
+     */
+    internal fun getMangaDir(source: Source, manga: Manga): UniFile {
         return downloadsDir
                 .subFile(getSourceDirName(source))!!
                 .subFile(getMangaDirName(manga))!!
     }
 
-    fun getChapterDir(mangaDir: UniFile, chapter: Chapter): UniFile {
-        return mangaDir.subFile(getChapterDirName(chapter))!!
-    }
-
+    /**
+     * Returns the download directory for a manga if it exists.
+     *
+     * @param source the source of the manga.
+     * @param manga the manga to query.
+     */
     fun findMangaDir(source: Source, manga: Manga): UniFile? {
         val sourceDir = downloadsDir.findFile(getSourceDirName(source))
         return sourceDir?.findFile(getMangaDirName(manga))
     }
 
+    /**
+     * Returns the download directory for a chapter if it exists.
+     *
+     * @param source the source of the chapter.
+     * @param manga the manga of the chapter.
+     * @param chapter the chapter to query.
+     */
     fun findChapterDir(source: Source, manga: Manga, chapter: Chapter): UniFile? {
         val mangaDir = findMangaDir(source, manga)
         return mangaDir?.findFile(getChapterDirName(chapter))
     }
 
+    /**
+     * Returns the download directory name for a source.
+     *
+     * @param source the source to query.
+     */
     fun getSourceDirName(source: Source): String {
         return source.toString()
     }
 
+    /**
+     * Returns the download directory name for a manga.
+     *
+     * @param manga the manga to query.
+     */
     fun getMangaDirName(manga: Manga): String {
-        return buildValidFatFilename(manga.title).trim('.', ' ')
+        return buildValidFatFilename(manga.title.trim('.', ' '))
     }
 
+    /**
+     * Returns the chapter directory name for a chapter.
+     *
+     * @param chapter the chapter to query.
+     */
     fun getChapterDirName(chapter: Chapter): String {
-        return buildValidFatFilename(chapter.name).trim('.', ' ')
+        return buildValidFatFilename(chapter.name.trim('.', ' '))
     }
 
     /**
@@ -61,7 +99,7 @@ class DownloadProvider(private val context: Context) {
      * replacing any invalid characters with "_".
      */
     private fun buildValidFatFilename(name: String): String {
-        if (name.isNullOrBlank() || "." == name || ".." == name) {
+        if (name.isNullOrBlank()) {
             return "(invalid)"
         }
         val res = StringBuilder(name.length)
@@ -77,6 +115,9 @@ class DownloadProvider(private val context: Context) {
         return res.toString().take(255)
     }
 
+    /**
+     * Returns true if the given character is a valid filename character, false otherwise.
+     */
     private fun isValidFatFilenameChar(c: Char): Boolean {
         if (0x00.toChar() <= c && c <= 0x1f.toChar()) {
             return false

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -99,7 +99,7 @@ class DownloadProvider(private val context: Context) {
      * replacing any invalid characters with "_".
      */
     private fun buildValidFatFilename(name: String): String {
-        if (name.isNullOrBlank()) {
+        if (name.isNullOrEmpty()) {
             return "(invalid)"
         }
         val res = StringBuilder(name.length)
@@ -111,8 +111,8 @@ class DownloadProvider(private val context: Context) {
             }
         }
         // Even though vfat allows 255 UCS-2 chars, we might eventually write to
-        // ext4 through a FUSE layer, so use that limit.
-        return res.toString().take(255)
+        // ext4 through a FUSE layer, so use that limit minus 5 reserved characters.
+        return res.toString().take(250)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -49,11 +49,11 @@ class DownloadProvider(private val context: Context) {
     }
 
     fun getMangaDirName(manga: Manga): String {
-        return buildValidFatFilename(manga.title)
+        return buildValidFatFilename(manga.title).trim('.', ' ')
     }
 
     fun getChapterDirName(chapter: Chapter): String {
-        return buildValidFatFilename(chapter.name)
+        return buildValidFatFilename(chapter.name).trim('.', ' ')
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadService.kt
@@ -52,7 +52,7 @@ class DownloadService : Service() {
     override fun onDestroy() {
         queueRunningSubscription?.unsubscribe()
         networkChangeSubscription?.unsubscribe()
-        downloadManager.destroySubscriptions()
+        downloadManager.stopDownloads()
         destroyWakeLock()
         super.onDestroy()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadStore.kt
@@ -1,0 +1,71 @@
+package eu.kanade.tachiyomi.data.download
+
+import android.content.Context
+import com.google.gson.Gson
+import eu.kanade.tachiyomi.data.database.DatabaseHelper
+import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.download.model.Download
+import eu.kanade.tachiyomi.data.source.SourceManager
+import eu.kanade.tachiyomi.data.source.online.OnlineSource
+import uy.kohesive.injekt.injectLazy
+
+class DownloadStore(context: Context) {
+
+    private val preferences = context.getSharedPreferences("active_downloads", Context.MODE_PRIVATE)
+
+    private val gson: Gson by injectLazy()
+
+    private val sourceManager: SourceManager by injectLazy()
+
+    private val db: DatabaseHelper by injectLazy()
+
+    private var counter = 0
+
+    fun add(download: Download) {
+        preferences.edit()
+                .putString(getKey(download), encode(download))
+                .apply()
+    }
+
+    fun restore(): List<Download> {
+        val objs = preferences.all
+                .mapNotNull { it.value as? String }
+                .map { decode(it) }
+                .sortedBy { it.order }
+
+        val downloads = mutableListOf<Download>()
+        if (objs.isNotEmpty()) {
+            val cachedManga = mutableMapOf<Long, Manga?>()
+            for ((mangaId, chapterId) in objs) {
+                val manga = cachedManga.getOrPut(mangaId) {
+                    db.getManga(mangaId).executeAsBlocking()
+                } ?: continue
+                val source = sourceManager.get(manga.source) as? OnlineSource ?: continue
+                val chapter = db.getChapter(chapterId).executeAsBlocking() ?: continue
+                downloads.add(Download(source, manga, chapter))
+            }
+        }
+        preferences.edit().clear().apply()
+        return downloads
+    }
+
+    fun remove(download: Download) {
+        preferences.edit().remove(getKey(download)).apply()
+    }
+
+    private fun getKey(download: Download): String {
+        return download.chapter.id!!.toString()
+    }
+
+    private fun encode(download: Download): String {
+        val obj = DownloadObject(download.manga.id!!, download.chapter.id!!, counter++)
+        return gson.toJson(obj)
+    }
+
+    private fun decode(string: String): DownloadObject {
+        return gson.fromJson(string, DownloadObject::class.java)
+    }
+
+    data class DownloadObject(val mangaId: Long, val chapterId: Long, val order: Int)
+
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadStore.kt
@@ -42,14 +42,14 @@ class DownloadStore(context: Context) {
     private var counter = 0
 
     /**
-     * Adds a download to the store.
+     * Adds a list of downloads to the store.
      *
-     * @param download the download to add.
+     * @param downloads the list of downloads to add.
      */
-    fun add(download: Download) {
-        preferences.edit()
-                .putString(getKey(download), serialize(download))
-                .apply()
+    fun addAll(downloads: List<Download>) {
+        val editor = preferences.edit()
+        downloads.forEach { editor.putString(getKey(it), serialize(it)) }
+        editor.apply()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadStore.kt
@@ -10,7 +10,7 @@ import eu.kanade.tachiyomi.data.source.online.OnlineSource
 import uy.kohesive.injekt.injectLazy
 
 /**
- * This class is used to restore the active downloads after application restarts.
+ * This class is used to persist active downloads across application restarts.
  *
  * @param context the application context.
  */

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -1,0 +1,338 @@
+package eu.kanade.tachiyomi.data.download
+
+import android.content.Context
+import android.webkit.MimeTypeMap
+import com.hippo.unifile.UniFile
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.database.models.Chapter
+import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.download.model.Download
+import eu.kanade.tachiyomi.data.download.model.DownloadQueue
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.data.source.SourceManager
+import eu.kanade.tachiyomi.data.source.model.Page
+import eu.kanade.tachiyomi.data.source.online.OnlineSource
+import eu.kanade.tachiyomi.util.DynamicConcurrentMergeOperator
+import eu.kanade.tachiyomi.util.RetryWithDelay
+import eu.kanade.tachiyomi.util.isNullOrUnsubscribed
+import eu.kanade.tachiyomi.util.saveTo
+import okhttp3.Response
+import rx.Observable
+import rx.Subscription
+import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
+import rx.subjects.BehaviorSubject
+import rx.subjects.PublishSubject
+import timber.log.Timber
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.*
+
+class Downloader(val context: Context, val queue: DownloadQueue, val provider: DownloadProvider) {
+
+    private val sourceManager: SourceManager = Injekt.get()
+    private val preferences: PreferencesHelper = Injekt.get()
+
+    private val downloadsQueueSubject = PublishSubject.create<List<Download>>()
+
+    private var downloadsSubscription: Subscription? = null
+
+    private val notifier by lazy { DownloadNotifier(context) }
+    val runningSubject: BehaviorSubject<Boolean> = BehaviorSubject.create()
+
+    private val threadsSubject = BehaviorSubject.create<Int>()
+
+    private var threadsSubscription: Subscription? = null
+
+    @Volatile var isRunning: Boolean = false
+        private set
+
+    fun start(): Boolean {
+        if (queue.isEmpty())
+            return false
+
+        if (downloadsSubscription.isNullOrUnsubscribed())
+            initializeSubscriptions()
+
+        val pending = ArrayList<Download>()
+        for (download in queue) {
+            if (download.status != Download.DOWNLOADED) {
+                if (download.status != Download.QUEUE) download.status = Download.QUEUE
+                pending.add(download)
+            }
+        }
+        downloadsQueueSubject.onNext(pending)
+
+        return !pending.isEmpty()
+    }
+
+    fun stop(errorMessage: String? = null) {
+        destroySubscriptions()
+        for (download in queue) {
+            if (download.status == Download.DOWNLOADING) {
+                download.status = Download.ERROR
+            }
+        }
+        errorMessage?.let { notifier.onError(it) }
+    }
+
+    fun clearQueue() {
+        destroySubscriptions()
+        queue.clear()
+        notifier.onClear()
+    }
+
+    private fun initializeSubscriptions() {
+        if (isRunning) return
+        isRunning = true
+
+        threadsSubscription?.unsubscribe()
+        threadsSubscription = preferences.downloadThreads().asObservable()
+                .subscribe {
+                    threadsSubject.onNext(it)
+                    notifier.multipleDownloadThreads = it > 1
+                }
+
+        downloadsSubscription?.unsubscribe()
+        downloadsSubscription = downloadsQueueSubject.flatMap { Observable.from(it) }
+                .lift(DynamicConcurrentMergeOperator<Download, Download>({ downloadChapter(it) }, threadsSubject))
+                .onBackpressureBuffer()
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    // Delete successful downloads from queue
+                    if (it.status == Download.DOWNLOADED) {
+                        // remove downloaded chapter from queue
+                        queue.del(it)
+                        notifier.onProgressChange(queue)
+                    }
+                    if (areAllDownloadsFinished()) {
+                        DownloadService.stop(context)
+                    }
+                }, { error ->
+                    DownloadService.stop(context)
+                    Timber.e(error)
+                    notifier.onError(error.message)
+                })
+
+        runningSubject.onNext(true)
+    }
+
+    private fun destroySubscriptions() {
+        if (!isRunning) return
+        isRunning = false
+        runningSubject.onNext(false)
+
+        downloadsSubscription?.unsubscribe()
+        downloadsSubscription = null
+
+        threadsSubscription?.unsubscribe()
+        threadsSubscription = null
+    }
+
+    // Create a download object for every chapter and add them to the downloads queue
+    fun downloadChapters(manga: Manga, chapters: List<Chapter>) {
+        val source = sourceManager.get(manga.source) as? OnlineSource ?: return
+
+        // Add chapters to queue from the start
+        val sortedChapters = chapters.sortedByDescending { it.source_order }
+
+        // Used to avoid downloading chapters with the same name
+        val addedChapters = ArrayList<String>()
+        val pending = ArrayList<Download>()
+
+        for (chapter in sortedChapters) {
+            if (addedChapters.contains(chapter.name))
+                continue
+
+            addedChapters.add(chapter.name)
+            val download = Download(source, manga, chapter)
+
+            if (!prepareDownload(download)) {
+                queue.add(download)
+                pending.add(download)
+            }
+        }
+
+        // Initialize queue size
+        notifier.initialQueueSize = queue.size
+        // Show notification
+        notifier.onProgressChange(queue)
+
+        if (isRunning) downloadsQueueSubject.onNext(pending)
+    }
+
+    // Prepare the download. Returns true if the chapter is already downloaded
+    private fun prepareDownload(download: Download): Boolean {
+        // If the chapter is already queued, don't add it again
+        for (queuedDownload in queue) {
+            if (download.chapter.id == queuedDownload.chapter.id)
+                return true
+        }
+
+        val mangaDir = provider.getMangaDir(download.source, download.manga)
+        val filename = provider.getChapterDirName(download.chapter)
+        val chapterDir = mangaDir.subFile(filename)!!
+
+        if (chapterDir.exists())
+            return true
+
+        download.directory = chapterDir
+        download.filename = filename
+        return false
+    }
+
+    // Download the entire chapter
+    private fun downloadChapter(download: Download): Observable<Download> {
+        val tmpDir = download.directory.parentFile!!.subFile("${download.filename}_tmp")!!
+
+        val pageListObservable: Observable<List<Page>> = if (download.pages == null)
+        // Pull page list from network and add them to download object
+            download.source.fetchPageListFromNetwork(download.chapter)
+                    .doOnNext { pages ->
+                        download.pages = pages
+                    }
+        else
+        // Or if the page list already exists, start from the file
+            Observable.just(download.pages)
+
+        return Observable.defer {
+            pageListObservable
+                    .doOnNext { pages ->
+                        tmpDir.ensureDir()
+
+                        // Delete all temporary files
+                        tmpDir.listFiles()
+                                ?.filter { it.name!!.endsWith(".tmp") }
+                                ?.forEach { it.delete() }
+
+                        download.downloadedImages = 0
+                        download.status = Download.DOWNLOADING
+                    }
+                    // Get all the URLs to the source images, fetch pages if necessary
+                    .flatMap { download.source.fetchAllImageUrlsFromPageList(it) }
+                    // Start downloading images, consider we can have downloaded images already
+                    .concatMap { page -> getOrDownloadImage(page, download, tmpDir) }
+                    // Do when page is downloaded.
+                    .doOnNext {
+                        notifier.onProgressChange(download, queue)
+                    }
+                    // Do after download completes
+                    .doOnCompleted { onDownloadCompleted(download, tmpDir) }
+                    .toList()
+                    .map { pages -> download }
+                    // If the page list threw, it will resume here
+                    .onErrorReturn { error ->
+                        download.status = Download.ERROR
+                        notifier.onError(error.message, download.chapter.name)
+                        download
+                    }
+        }.subscribeOn(Schedulers.io())
+    }
+
+    // Get the image from the filesystem if it exists or download from network
+    private fun getOrDownloadImage(page: Page, download: Download, tmpDir: UniFile): Observable<Page> {
+        // If the image URL is empty, do nothing
+        if (page.imageUrl == null)
+            return Observable.just(page)
+
+        val filename = String.format("%03d", page.pageNumber + 1)
+        val tmpFile = tmpDir.findFile("$filename.tmp")
+
+        // Delete temp file if it exists.
+        tmpFile?.delete()
+
+        // Try to find the image file.
+        val imageFile = tmpDir.listFiles()!!.find { it.name!!.startsWith("$filename.")}
+
+        // If the image is already downloaded, do nothing. Otherwise download from network
+        val pageObservable = if (imageFile != null)
+            Observable.just(imageFile)
+        else
+            downloadImage(page, download.source, tmpDir, filename)
+
+        return pageObservable
+                // When the image is ready, set image path, progress (just in case) and status
+                .doOnNext { file ->
+                    page.uri = file.uri
+                    page.progress = 100
+                    download.downloadedImages++
+                    page.status = Page.READY
+                }
+                .map { page }
+                // Mark this page as error and allow to download the remaining
+                .onErrorReturn {
+                    page.progress = 0
+                    page.status = Page.ERROR
+                    page
+                }
+    }
+
+    // Save image on disk
+    private fun downloadImage(page: Page, source: OnlineSource, tmpDir: UniFile, filename: String): Observable<UniFile> {
+        page.status = Page.DOWNLOAD_IMAGE
+        page.progress = 0
+        return source.imageResponse(page)
+                .map { response ->
+                    val file = tmpDir.createFile("$filename.tmp")
+                    try {
+                        response.body().source().saveTo(file.openOutputStream())
+                        val extension = getFileExtension(response, file)
+                        file.renameTo("$filename.$extension")
+                    } catch (e: Exception) {
+                        response.close()
+                        file.delete()
+                        throw e
+                    }
+                    file
+                }
+                // Retry 3 times, waiting 2, 4 and 8 seconds between attempts.
+                .retryWhen(RetryWithDelay(3, { (2 shl it - 1) * 1000 }, Schedulers.trampoline()))
+    }
+
+    private fun getFileExtension(response: Response, file: UniFile): String? {
+        val contentType = response.body().contentType()
+        val mimeStr = if (contentType != null) {
+            "${contentType.type()}/${contentType.subtype()}"
+        } else {
+            context.contentResolver.getType(file.uri)
+        }
+        return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeStr)
+    }
+
+    // Called when a download finishes. This doesn't mean the download was successful, so we check it
+    private fun onDownloadCompleted(download: Download, tmpDir: UniFile) {
+        var actualProgress = 0
+        var status = Download.DOWNLOADED
+
+        // If any page has an error, the download result will be error
+        for (page in download.pages!!) {
+            actualProgress += page.progress
+            if (page.status != Page.READY) {
+                status = Download.ERROR
+                notifier.onError(context.getString(R.string.download_notifier_page_ready_error), download.chapter.name)
+            }
+        }
+        // Ensure that the chapter folder has all the images
+        val downloadedImages = tmpDir.listFiles()!!.filterNot { it.name!!.endsWith(".tmp") }
+        if (downloadedImages.size < download.pages!!.size) {
+            status = Download.ERROR
+            notifier.onError(context.getString(R.string.download_notifier_page_error), download.chapter.name)
+        }
+
+        if (status == Download.DOWNLOADED) {
+            tmpDir.renameTo(download.filename)
+        }
+
+        download.totalProgress = actualProgress
+        download.status = status
+    }
+
+    fun areAllDownloadsFinished(): Boolean {
+        for (download in queue) {
+            if (download.status <= Download.DOWNLOADING)
+                return false
+        }
+        return true
+    }
+
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -95,7 +95,7 @@ class Downloader(private val context: Context, private val provider: DownloadPro
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({ downloads -> downloads.forEach {
-                    if (!isDownloadAllowed(it)) {
+                    if (isDownloadAllowed(it)) {
                         queue.add(it)
                     }
                 }}, { error -> Timber.e(error) })

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.data.download
 import android.content.Context
 import android.webkit.MimeTypeMap
 import com.hippo.unifile.UniFile
+import com.jakewharton.rxrelay.BehaviorRelay
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
@@ -42,7 +43,8 @@ class Downloader(val context: Context, val provider: DownloadProvider) {
     private var downloadsSubscription: Subscription? = null
 
     private val notifier by lazy { DownloadNotifier(context) }
-    val runningSubject: BehaviorSubject<Boolean> = BehaviorSubject.create()
+
+    val runningRelay: BehaviorRelay<Boolean> = BehaviorRelay.create(false)
 
     private val threadsSubject = BehaviorSubject.create<Int>()
 
@@ -128,13 +130,13 @@ class Downloader(val context: Context, val provider: DownloadProvider) {
                     notifier.onError(error.message)
                 })
 
-        runningSubject.onNext(true)
+        runningRelay.call(true)
     }
 
     private fun destroySubscriptions() {
         if (!isRunning) return
         isRunning = false
-        runningSubject.onNext(false)
+        runningRelay.call(false)
 
         downloadsSubscription?.unsubscribe()
         downloadsSubscription = null

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -305,7 +305,7 @@ class Downloader(private val context: Context, private val provider: DownloadPro
         if (page.imageUrl == null)
             return Observable.just(page)
 
-        val filename = String.format("%03d", page.pageNumber + 1)
+        val filename = String.format("%03d", page.index + 1)
         val tmpFile = tmpDir.findFile("$filename.tmp")
 
         // Delete temp file if it exists.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -29,7 +29,7 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.util.*
 
-class Downloader(val context: Context, val provider: DownloadProvider) {
+class Downloader(private val context: Context, private val provider: DownloadProvider) {
 
     private val store = DownloadStore(context)
 
@@ -89,13 +89,17 @@ class Downloader(val context: Context, val provider: DownloadProvider) {
                 .filter { it.status == Download.DOWNLOADING }
                 .forEach { it.status = Download.ERROR }
 
-        reason?.let { notifier.onError(it) }
+        if (reason != null) {
+            notifier.onWarning(reason)
+        } else {
+            notifier.dismiss()
+        }
     }
 
     fun clearQueue() {
         destroySubscriptions()
         queue.clear()
-        notifier.onClear()
+        notifier.dismiss()
     }
 
     private fun initializeSubscriptions() {
@@ -343,11 +347,7 @@ class Downloader(val context: Context, val provider: DownloadProvider) {
     }
 
     private fun areAllDownloadsFinished(): Boolean {
-        for (download in queue) {
-            if (download.status <= Download.DOWNLOADING)
-                return false
-        }
-        return true
+        return queue.none { it.status <= Download.DOWNLOADING }
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -81,14 +81,13 @@ class Downloader(val context: Context, val provider: DownloadProvider) {
         return !pending.isEmpty()
     }
 
-    fun stop(errorMessage: String? = null) {
+    fun stop(reason: String? = null) {
         destroySubscriptions()
-        for (download in queue) {
-            if (download.status == Download.DOWNLOADING) {
-                download.status = Download.ERROR
-            }
-        }
-        errorMessage?.let { notifier.onError(it) }
+        queue
+                .filter { it.status == Download.DOWNLOADING }
+                .forEach { it.status = Download.ERROR }
+
+        reason?.let { notifier.onError(it) }
     }
 
     fun clearQueue() {
@@ -341,7 +340,7 @@ class Downloader(val context: Context, val provider: DownloadProvider) {
         download.status = status
     }
 
-    fun areAllDownloadsFinished(): Boolean {
+    private fun areAllDownloadsFinished(): Boolean {
         for (download in queue) {
             if (download.status <= Download.DOWNLOADING)
                 return false

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
@@ -9,7 +9,10 @@ import rx.subjects.PublishSubject
 
 class Download(val source: OnlineSource, val manga: Manga, val chapter: Chapter) {
 
-    lateinit var directory: UniFile
+    @Transient lateinit var directory: UniFile
+
+    @Transient lateinit var filename: String
+
 
     var pages: List<Page>? = null
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
@@ -11,9 +11,6 @@ class Download(val source: OnlineSource, val manga: Manga, val chapter: Chapter)
 
     @Transient lateinit var directory: UniFile
 
-    @Transient lateinit var filename: String
-
-
     var pages: List<Page>? = null
 
     @Volatile @Transient var totalProgress: Int = 0

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
@@ -1,15 +1,15 @@
 package eu.kanade.tachiyomi.data.download.model
 
+import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.source.model.Page
 import eu.kanade.tachiyomi.data.source.online.OnlineSource
 import rx.subjects.PublishSubject
-import java.io.File
 
 class Download(val source: OnlineSource, val manga: Manga, val chapter: Chapter) {
 
-    lateinit var directory: File
+    lateinit var directory: UniFile
 
     var pages: List<Page>? = null
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/model/Download.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.data.download.model
 
-import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.source.model.Page
@@ -8,8 +7,6 @@ import eu.kanade.tachiyomi.data.source.online.OnlineSource
 import rx.subjects.PublishSubject
 
 class Download(val source: OnlineSource, val manga: Manga, val chapter: Chapter) {
-
-    @Transient lateinit var directory: UniFile
 
     var pages: List<Page>? = null
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/model/DownloadQueue.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/model/DownloadQueue.kt
@@ -1,12 +1,15 @@
 package eu.kanade.tachiyomi.data.download.model
 
 import eu.kanade.tachiyomi.data.database.models.Chapter
+import eu.kanade.tachiyomi.data.download.DownloadStore
 import eu.kanade.tachiyomi.data.source.model.Page
 import rx.Observable
 import rx.subjects.PublishSubject
 import java.util.concurrent.CopyOnWriteArrayList
 
-class DownloadQueue(private val queue: MutableList<Download> = CopyOnWriteArrayList<Download>())
+class DownloadQueue(
+        private val store: DownloadStore,
+        private val queue: MutableList<Download> = CopyOnWriteArrayList<Download>())
 : List<Download> by queue {
 
     private val statusSubject = PublishSubject.create<Download>()
@@ -16,11 +19,13 @@ class DownloadQueue(private val queue: MutableList<Download> = CopyOnWriteArrayL
     fun add(download: Download): Boolean {
         download.setStatusSubject(statusSubject)
         download.status = Download.QUEUE
+        store.add(download)
         return queue.add(download)
     }
 
     fun del(download: Download) {
         val removed = queue.remove(download)
+        store.remove(download)
         download.setStatusSubject(null)
         if (removed) {
             removeSubject.onNext(download)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.data.preference
 
 import android.content.Context
+import android.net.Uri
 import android.os.Environment
 import android.preference.PreferenceManager
 import com.f2prateek.rx.preferences.Preference
@@ -9,7 +10,6 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.mangasync.MangaSyncService
 import eu.kanade.tachiyomi.data.source.Source
 import java.io.File
-import java.io.IOException
 
 fun <T> Preference<T>.getOrDefault(): T = get() ?: defaultValue()!!
 
@@ -20,17 +20,9 @@ class PreferencesHelper(context: Context) {
     private val prefs = PreferenceManager.getDefaultSharedPreferences(context)
     private val rxPrefs = RxSharedPreferences.create(prefs)
 
-    private val defaultDownloadsDir = File(Environment.getExternalStorageDirectory().absolutePath +
-            File.separator + context.getString(R.string.app_name), "downloads")
-
-    init {
-        // Don't display downloaded chapters in gallery apps creating a ".nomedia" file
-        try {
-            File(downloadsDirectory().getOrDefault(), ".nomedia").createNewFile()
-        } catch (e: IOException) {
-            /* Ignore */
-        }
-    }
+    private val defaultDownloadsDir = Uri.fromFile(
+            File(Environment.getExternalStorageDirectory().absolutePath + File.separator +
+                    context.getString(R.string.app_name), "downloads"))
 
     fun startScreen() = prefs.getInt(keys.startScreen, 1)
 
@@ -112,7 +104,7 @@ class PreferencesHelper(context: Context) {
                 .apply()
     }
 
-    fun downloadsDirectory() = rxPrefs.getString(keys.downloadsDirectory, defaultDownloadsDir.absolutePath)
+    fun downloadsDirectory() = rxPrefs.getString(keys.downloadsDirectory, defaultDownloadsDir.toString())
 
     fun downloadThreads() = rxPrefs.getInteger(keys.downloadThreads, 1)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/source/model/Page.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/source/model/Page.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.data.source.model
 
+import android.net.Uri
 import eu.kanade.tachiyomi.data.network.ProgressListener
 import eu.kanade.tachiyomi.ui.reader.ReaderChapter
 import rx.subjects.Subject
@@ -8,7 +9,7 @@ class Page(
         val pageNumber: Int,
         val url: String = "",
         var imageUrl: String? = null,
-        @Transient var imagePath: String? = null
+        @Transient var imagePath: Uri? = null
 ) : ProgressListener {
 
     @Transient lateinit var chapter: ReaderChapter

--- a/app/src/main/java/eu/kanade/tachiyomi/data/source/model/Page.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/source/model/Page.kt
@@ -6,7 +6,7 @@ import rx.subjects.Subject
 
 class Page(
         val pageNumber: Int,
-        val url: String,
+        val url: String = "",
         var imageUrl: String? = null,
         @Transient var imagePath: String? = null
 ) : ProgressListener {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/source/model/Page.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/source/model/Page.kt
@@ -9,7 +9,7 @@ class Page(
         val pageNumber: Int,
         val url: String = "",
         var imageUrl: String? = null,
-        @Transient var imagePath: Uri? = null
+        @Transient var uri: Uri? = null
 ) : ProgressListener {
 
     @Transient lateinit var chapter: ReaderChapter

--- a/app/src/main/java/eu/kanade/tachiyomi/data/source/model/Page.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/source/model/Page.kt
@@ -6,7 +6,7 @@ import eu.kanade.tachiyomi.ui.reader.ReaderChapter
 import rx.subjects.Subject
 
 class Page(
-        val pageNumber: Int,
+        val index: Int,
         val url: String = "",
         var imageUrl: String? = null,
         @Transient var uri: Uri? = null

--- a/app/src/main/java/eu/kanade/tachiyomi/data/source/online/OnlineSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/source/online/OnlineSource.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.data.source.online
 
+import android.net.Uri
 import eu.kanade.tachiyomi.data.cache.ChapterCache
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
@@ -416,7 +417,7 @@ abstract class OnlineSource() : Source {
                     }
                 }
                 .doOnNext {
-                    page.imagePath = chapterCache.getImagePath(imageUrl)
+                    page.imagePath = Uri.fromFile(chapterCache.getImagePath(imageUrl))
                     page.status = Page.READY
                 }
                 .doOnError { page.status = Page.ERROR }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/source/online/OnlineSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/source/online/OnlineSource.kt
@@ -417,7 +417,7 @@ abstract class OnlineSource() : Source {
                     }
                 }
                 .doOnNext {
-                    page.imagePath = Uri.fromFile(chapterCache.getImagePath(imageUrl))
+                    page.uri = Uri.fromFile(chapterCache.getImagePath(imageUrl))
                     page.status = Page.READY
                 }
                 .doOnError { page.status = Page.ERROR }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadFragment.kt
@@ -95,7 +95,7 @@ class DownloadFragment : BaseRxFragment<DownloadPresenter>() {
         recycler.setHasFixedSize(true)
 
         // Suscribe to changes
-        subscriptions += presenter.downloadManager.runningSubject
+        subscriptions += DownloadService.runningRelay
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { onQueueStatusChange(it) }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadFragment.kt
@@ -6,6 +6,7 @@ import android.view.*
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.DownloadService
 import eu.kanade.tachiyomi.data.download.model.Download
+import eu.kanade.tachiyomi.data.source.model.Page
 import eu.kanade.tachiyomi.ui.base.fragment.BaseRxFragment
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.util.plusAssign
@@ -161,7 +162,7 @@ class DownloadFragment : BaseRxFragment<DownloadPresenter>() {
                 // Get the sum of percentages for all the pages.
                 .flatMap {
                     Observable.from(download.pages)
-                            .map { it.progress }
+                            .map(Page::progress)
                             .reduce { x, y -> x + y }
                 }
                 // Keep only the latest emission to avoid backpressure.
@@ -209,6 +210,8 @@ class DownloadFragment : BaseRxFragment<DownloadPresenter>() {
      * @param downloads the downloads from the queue.
      */
     fun onNextDownloads(downloads: List<Download>) {
+        activity.supportInvalidateOptionsMenu()
+        setInformationView()
         adapter.setItems(downloads)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadFragment.kt
@@ -84,11 +84,11 @@ class DownloadFragment : BaseRxFragment<DownloadPresenter>() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { onQueueStatusChange(it) }
 
-        subscriptions += presenter.getStatusObservable()
+        subscriptions += presenter.getDownloadStatusObservable()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { onStatusChange(it) }
 
-        subscriptions += presenter.getProgressObservable()
+        subscriptions += presenter.getDownloadProgressObservable()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { onUpdateDownloadedPages(it) }
     }
@@ -210,10 +210,6 @@ class DownloadFragment : BaseRxFragment<DownloadPresenter>() {
      */
     fun onNextDownloads(downloads: List<Download>) {
         adapter.setItems(downloads)
-    }
-
-    fun onDownloadRemoved(position: Int) {
-        adapter.notifyItemRemoved(position)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadFragment.kt
@@ -31,21 +31,6 @@ class DownloadFragment : BaseRxFragment<DownloadPresenter>() {
     private lateinit var adapter: DownloadAdapter
 
     /**
-     * Menu item to start the queue.
-     */
-    private var startButton: MenuItem? = null
-
-    /**
-     * Menu item to pause the queue.
-     */
-    private var pauseButton: MenuItem? = null
-
-    /**
-     * Menu item to clear the queue.
-     */
-    private var clearButton: MenuItem? = null
-
-    /**
      * Subscription list to be cleared during [onDestroyView].
      */
     private val subscriptions by lazy { CompositeSubscription() }
@@ -119,23 +104,17 @@ class DownloadFragment : BaseRxFragment<DownloadPresenter>() {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.download_queue, menu)
+    }
 
+    override fun onPrepareOptionsMenu(menu: Menu) {
         // Set start button visibility.
-        startButton = menu.findItem(R.id.start_queue).apply {
-            isVisible = !isRunning && !presenter.downloadQueue.isEmpty()
-        }
+        menu.findItem(R.id.start_queue).isVisible = !isRunning && !presenter.downloadQueue.isEmpty()
 
         // Set pause button visibility.
-        pauseButton = menu.findItem(R.id.pause_queue).apply {
-            isVisible = isRunning
-        }
+        menu.findItem(R.id.pause_queue).isVisible = isRunning
 
         // Set clear button visibility.
-        clearButton = menu.findItem(R.id.clear_queue).apply {
-            if (!presenter.downloadQueue.isEmpty()) {
-                isVisible = true
-            }
-        }
+        menu.findItem(R.id.clear_queue).isVisible = !presenter.downloadQueue.isEmpty()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -218,9 +197,7 @@ class DownloadFragment : BaseRxFragment<DownloadPresenter>() {
      */
     private fun onQueueStatusChange(running: Boolean) {
         isRunning = running
-        startButton?.isVisible = !running && !presenter.downloadQueue.isEmpty()
-        pauseButton?.isVisible = running
-        clearButton?.isVisible = !presenter.downloadQueue.isEmpty()
+        activity.supportInvalidateOptionsMenu()
 
         // Check if download queue is empty and update information accordingly.
         setInformationView()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadPresenter.kt
@@ -31,9 +31,8 @@ class DownloadPresenter : BasePresenter<DownloadFragment>() {
         super.onCreate(savedState)
 
         downloadQueue.getUpdatedObservable()
-                .startWith(Unit)
                 .observeOn(AndroidSchedulers.mainThread())
-                .map { ArrayList(downloadQueue) }
+                .map { ArrayList(it) }
                 .subscribeLatestCache(DownloadFragment::onNextDownloads, { view, error ->
                     Timber.e(error)
                 })

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadPresenter.kt
@@ -29,36 +29,22 @@ class DownloadPresenter : BasePresenter<DownloadFragment>() {
 
     override fun onCreate(savedState: Bundle?) {
         super.onCreate(savedState)
-        
-        Observable.just(ArrayList(downloadQueue))
-                .doOnNext { syncQueue(it) }
-                .subscribeLatestCache({ view, downloads ->
-                    view.onNextDownloads(downloads)
-                }, { view, error ->
+
+        downloadQueue.getUpdatedObservable()
+                .startWith(Unit)
+                .observeOn(AndroidSchedulers.mainThread())
+                .map { ArrayList(downloadQueue) }
+                .subscribeLatestCache(DownloadFragment::onNextDownloads, { view, error ->
                     Timber.e(error)
                 })
     }
 
-    private fun syncQueue(queue: MutableList<Download>) {
-        add(downloadQueue.getRemovedObservable()
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe { download ->
-                    val position = queue.indexOf(download)
-                    if (position != -1) {
-                        queue.removeAt(position)
-
-                        @Suppress("DEPRECATION")
-                        view?.onDownloadRemoved(position)
-                    }
-                })
-    }
-
-    fun getStatusObservable(): Observable<Download> {
+    fun getDownloadStatusObservable(): Observable<Download> {
         return downloadQueue.getStatusObservable()
                 .startWith(downloadQueue.getActiveDownloads())
     }
 
-    fun getProgressObservable(): Observable<Download> {
+    fun getDownloadProgressObservable(): Observable<Download> {
         return downloadQueue.getProgressObservable()
                 .onBackpressureBuffer()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -185,15 +185,12 @@ class LibraryPresenter : BasePresenter<LibraryFragment>() {
             }
 
             if (prefFilterDownloaded) {
-                val mangaDir = downloadManager.getAbsoluteMangaDirectory(source, manga)
+                val mangaDir = downloadManager.getMangaDir(source, manga)
 
                 if (mangaDir.exists()) {
-                    for (file in mangaDir.listFiles()) {
-                        if (file.isDirectory && file.listFiles().isNotEmpty()) {
-                            hasDownloaded = true
-                            break
-                        }
-                    }
+                    hasDownloaded = mangaDir.listFiles()?.any { file ->
+                        file.isDirectory && file.listFiles()!!.isNotEmpty()
+                    } ?: false
                 }
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -185,12 +185,10 @@ class LibraryPresenter : BasePresenter<LibraryFragment>() {
             }
 
             if (prefFilterDownloaded) {
-                val mangaDir = downloadManager.getMangaDir(source, manga)
+                val mangaDir = downloadManager.findMangaDir(source, manga)
 
-                if (mangaDir.exists()) {
-                    hasDownloaded = mangaDir.listFiles()?.any { file ->
-                        file.isDirectory && file.listFiles()!!.isNotEmpty()
-                    } ?: false
+                if (mangaDir != null) {
+                    hasDownloaded = mangaDir.listFiles()?.any { it.isDirectory } ?: false
                 }
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/ChangelogDialogFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/ChangelogDialogFragment.kt
@@ -38,7 +38,7 @@ class ChangelogDialogFragment : DialogFragment() {
     override fun onCreateDialog(savedState: Bundle?): Dialog {
         val view = WhatsNewRecyclerView(context)
         return MaterialDialog.Builder(activity)
-                .title("Changelog")
+                .title(if (BuildConfig.DEBUG) "Notices" else "Changelog")
                 .customView(view, false)
                 .positiveText(android.R.string.yes)
                 .build()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersPresenter.kt
@@ -348,7 +348,7 @@ class ChaptersPresenter : BasePresenter<ChaptersFragment>() {
      * @param chapter the chapter to delete.
      */
     private fun deleteChapter(chapter: ChapterModel) {
-        downloadManager.queue.del(chapter)
+        downloadManager.queue.remove(chapter)
         downloadManager.deleteChapter(source, manga, chapter)
         chapter.status = Download.NOT_DOWNLOADED
         chapter.download = null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersPresenter.kt
@@ -330,10 +330,6 @@ class ChaptersPresenter : BasePresenter<ChaptersFragment>() {
      * @param chapters the list of chapters to delete.
      */
     fun deleteChapters(chapters: List<ChapterModel>) {
-        val wasRunning = downloadManager.isRunning
-        if (wasRunning) {
-            DownloadService.stop(context)
-        }
         Observable.from(chapters)
                 .doOnNext { deleteChapter(it) }
                 .toList()
@@ -342,9 +338,6 @@ class ChaptersPresenter : BasePresenter<ChaptersFragment>() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeFirst({ view, result ->
                     view.onChaptersDeleted()
-                    if (wasRunning) {
-                        DownloadService.start(context)
-                    }
                 }, { view, error ->
                     view.onChaptersDeletedError(error)
                 })

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ChapterLoader.kt
@@ -70,7 +70,7 @@ class ChapterLoader(
     private fun retrievePageList(chapter: ReaderChapter) = Observable.just(chapter)
             .flatMap {
                 // Check if the chapter is downloaded.
-                chapter.isDownloaded = downloadManager.isChapterDownloaded(source, manga, chapter)
+                chapter.isDownloaded = downloadManager.findChapterDir(source, manga, chapter) != null
 
                 if (chapter.isDownloaded) {
                     // Fetch the page list from disk.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ChapterLoader.kt
@@ -72,12 +72,13 @@ class ChapterLoader(
                 // Check if the chapter is downloaded.
                 chapter.isDownloaded = downloadManager.isChapterDownloaded(source, manga, chapter)
 
-                // Fetch the page list from disk.
-                if (chapter.isDownloaded)
-                    Observable.just(downloadManager.getSavedPageList(source, manga, chapter)!!)
-                // Fetch the page list from cache or fallback to network
-                else
+                if (chapter.isDownloaded) {
+                    // Fetch the page list from disk.
+                    downloadManager.buildPageList(source, manga, chapter)
+                } else {
+                    // Fetch the page list from cache or fallback to network
                     source.fetchPageList(chapter)
+                }
             }
             .doOnNext { pages ->
                 chapter.pages = pages
@@ -85,19 +86,9 @@ class ChapterLoader(
             }
 
     private fun loadPages(chapter: ReaderChapter) {
-        if (chapter.isDownloaded) {
-            loadDownloadedPages(chapter)
-        } else {
+        if (!chapter.isDownloaded) {
             loadOnlinePages(chapter)
         }
-    }
-
-    private fun loadDownloadedPages(chapter: ReaderChapter) {
-        val chapterDir = downloadManager.getAbsoluteChapterDirectory(source, manga, chapter)
-        subscriptions += Observable.from(chapter.pages!!)
-                .flatMap { downloadManager.getDownloadedImage(it, chapterDir) }
-                .subscribeOn(Schedulers.io())
-                .subscribe()
     }
 
     private fun loadOnlinePages(chapter: ReaderChapter) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -264,7 +264,7 @@ class ReaderActivity : BaseRxActivity<ReaderPresenter>() {
         val activePage = pages.getOrElse(chapter.requestedPage) { pages.first() }
 
         viewer?.onPageListReady(chapter, activePage)
-        setActiveChapter(chapter, activePage.pageNumber)
+        setActiveChapter(chapter, activePage.index)
     }
 
     fun onEnterChapter(chapter: ReaderChapter, currentPage: Int) {
@@ -331,7 +331,7 @@ class ReaderActivity : BaseRxActivity<ReaderPresenter>() {
     fun onPageChanged(page: Page) {
         presenter.onPageChanged(page)
 
-        val pageNumber = page.pageNumber + 1
+        val pageNumber = page.index + 1
         val pageCount = page.chapter.pages!!.size
         page_number.text = "$pageNumber/$pageCount"
         if (page_seekbar.rotation != 180f) {
@@ -339,7 +339,7 @@ class ReaderActivity : BaseRxActivity<ReaderPresenter>() {
         } else {
             right_page_text.text = "$pageNumber"
         }
-        page_seekbar.progress = page.pageNumber
+        page_seekbar.progress = page.index
     }
 
     fun gotoPageInCurrentChapter(pageIndex: Int) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.graphics.Color
-import android.net.Uri
 import android.os.Build
 import android.os.Build.VERSION_CODES.KITKAT
 import android.os.Bundle
@@ -481,7 +480,7 @@ class ReaderActivity : BaseRxActivity<ReaderPresenter>() {
 
         val shareIntent = Intent().apply {
             action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_STREAM, Uri.parse(page.imagePath))
+            putExtra(Intent.EXTRA_STREAM, page.imagePath)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
             type = "image/jpeg"
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -480,7 +480,7 @@ class ReaderActivity : BaseRxActivity<ReaderPresenter>() {
 
         val shareIntent = Intent().apply {
             action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_STREAM, page.imagePath)
+            putExtra(Intent.EXTRA_STREAM, page.uri)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
             type = "image/jpeg"
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -414,7 +414,7 @@ class ReaderPresenter : BasePresenter<ReaderActivity>() {
      */
     fun onPageChanged(page: Page) {
         val chapter = page.chapter
-        chapter.last_page_read = page.pageNumber
+        chapter.last_page_read = page.index
         if (chapter.pages!!.last() === page) {
             chapter.read = true
         }
@@ -575,7 +575,7 @@ class ReaderPresenter : BasePresenter<ReaderActivity>() {
                     // File where the image will be saved.
                     // TODO Will storage access framework be required?
                     val destFile = File(pictureDirectory, manga.title + " - " + chapter.name +
-                            " - " + (page.pageNumber + 1))
+                            " - " + (page.index + 1))
 
                     inputStream.use { inp ->
                         destFile.outputStream().use { output ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -351,10 +351,9 @@ class ReaderPresenter : BasePresenter<ReaderActivity>() {
     fun retryPage(page: Page?) {
         if (page != null && source is OnlineSource) {
             page.status = Page.QUEUE
-            val path = page.imagePath
-            if (path != null && !page.chapter.isDownloaded) {
-                // TODO test
-                chapterCache.removeFileFromCache(path.encodedPath.substringAfterLast('/'))
+            val uri = page.uri
+            if (uri != null && !page.chapter.isDownloaded) {
+                chapterCache.removeFileFromCache(uri.encodedPath.substringAfterLast('/'))
             }
             loader.retryPage(page)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/notification/ImageNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/notification/ImageNotifier.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.ui.reader.notification
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.media.Image
 import android.support.v4.app.NotificationCompat
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/notification/ImageNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/notification/ImageNotifier.kt
@@ -5,8 +5,6 @@ import android.graphics.Bitmap
 import android.support.v4.app.NotificationCompat
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
-import com.bumptech.glide.request.animation.GlideAnimation
-import com.bumptech.glide.request.target.SimpleTarget
 import eu.kanade.tachiyomi.Constants
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.util.notificationManager
@@ -28,24 +26,25 @@ class ImageNotifier(private val context: Context) {
         get() = Constants.NOTIFICATION_DOWNLOAD_IMAGE_ID
 
     /**
-     * Called when image download/copy is complete
-     * @param file image file containing downloaded page image
+     * Called when image download/copy is complete. This method must be called in a background
+     * thread.
+     *
+     * @param file image file containing downloaded page image.
      */
     fun onComplete(file: File) {
+        val bitmap = Glide.with(context)
+                .load(file)
+                .asBitmap()
+                .diskCacheStrategy(DiskCacheStrategy.NONE)
+                .skipMemoryCache(true)
+                .into(720, 1280)
+                .get()
 
-        Glide.with(context).load(file).asBitmap().diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true).into(object : SimpleTarget<Bitmap>(720, 1280) {
-            /**
-             * The method that will be called when the resource load has finished.
-             * @param resource the loaded resource.
-             */
-            override fun onResourceReady(resource: Bitmap?, glideAnimation: GlideAnimation<in Bitmap>?) {
-                if (resource!= null){
-                    showCompleteNotification(file, resource)
-                }else{
-                    onError(null)
-                }
-            }
-        })
+        if (bitmap != null) {
+            showCompleteNotification(file, bitmap)
+        } else {
+            onError(null)
+        }
     }
 
     private fun showCompleteNotification(file: File, image: Bitmap) {
@@ -74,7 +73,7 @@ class ImageNotifier(private val context: Context) {
     }
 
     /**
-     * Clears the notification message
+     * Clears the notification message.
      */
     fun onClear() {
         context.notificationManager.cancel(notificationId)
@@ -87,8 +86,8 @@ class ImageNotifier(private val context: Context) {
 
 
     /**
-     * Called on error while downloading image
-     * @param error string containing error information
+     * Called on error while downloading image.
+     * @param error string containing error information.
      */
     fun onError(error: String?) {
         // Create notification

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/base/BaseReader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/base/BaseReader.kt
@@ -95,7 +95,7 @@ abstract class BaseReader : BaseFragment() {
 
         // Active chapter has changed.
         if (oldChapter.id != newChapter.id) {
-            readerActivity.onEnterChapter(newPage.chapter, newPage.pageNumber)
+            readerActivity.onEnterChapter(newPage.chapter, newPage.index)
         }
         // Request next chapter only when the conditions are met.
         if (pages.size - position < 5 && chapters.last().id == newChapter.id
@@ -125,7 +125,7 @@ abstract class BaseReader : BaseFragment() {
      */
     fun getPageIndex(search: Page): Int {
         for ((index, page) in pages.withIndex()) {
-            if (page.pageNumber == search.pageNumber && page.chapter.id == search.chapter.id) {
+            if (page.index == search.index && page.chapter.id == search.chapter.id) {
                 return index
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PageView.kt
@@ -223,7 +223,7 @@ class PageView @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
             path = "file:///" + path
         }
 
-        val file = UniFile.fromUri(context, Uri.parse(path))
+        val file = UniFile.fromSingleUri(context, Uri.parse(path))
         if (!file.exists()) {
             page.status = Page.ERROR
             return

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PageView.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.ui.reader.viewer.pager
 
 import android.content.Context
 import android.graphics.PointF
-import android.net.Uri
+import android.os.Build
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
@@ -24,6 +24,7 @@ import rx.Subscription
 import rx.android.schedulers.AndroidSchedulers
 import rx.subjects.PublishSubject
 import rx.subjects.SerializedSubject
+import java.io.File
 import java.util.concurrent.TimeUnit
 
 class PageView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null)
@@ -209,21 +210,18 @@ class PageView @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
      * Called when the page is ready.
      */
     private fun setImage() {
-        var path = page.imagePath
-        if (path == null) {
+        val uri = page.imagePath
+        if (uri == null) {
             page.status = Page.ERROR
             return
         }
 
-        // FIXME use Uri instead
-        if (!path.contains("://")) {
-            if (path.startsWith("/")) {
-                path = path.substring(1)
-            }
-            path = "file:///" + path
-        }
-
-        val file = UniFile.fromSingleUri(context, Uri.parse(path))
+        val file = if (Build.VERSION.SDK_INT < 21 || UniFile.isFileUri(uri)) {
+            UniFile.fromFile(File(uri.path))
+        } else {
+            // Tree uri returns the root folder
+            UniFile.fromSingleUri(context, uri)
+        }!!
         if (!file.exists()) {
             page.status = Page.ERROR
             return

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PageView.kt
@@ -210,7 +210,7 @@ class PageView @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
      * Called when the page is ready.
      */
     private fun setImage() {
-        val uri = page.imagePath
+        val uri = page.uri
         if (uri == null) {
             page.status = Page.ERROR
             return

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonHolder.kt
@@ -244,7 +244,7 @@ class WebtoonHolder(private val view: View, private val adapter: WebtoonAdapter)
      * Called when the page is ready.
      */
     private fun setImage() = with(view) {
-        val uri = page?.imagePath
+        val uri = page?.uri
         if (uri == null) {
             page?.status = Page.ERROR
             return

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonHolder.kt
@@ -1,11 +1,13 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.webtoon
 
+import android.os.Build
 import android.support.v7.widget.RecyclerView
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import com.davemorrissey.labs.subscaleview.ImageSource
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
+import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
@@ -242,14 +244,26 @@ class WebtoonHolder(private val view: View, private val adapter: WebtoonAdapter)
      * Called when the page is ready.
      */
     private fun setImage() = with(view) {
-        val path = page?.imagePath
-        if (path != null && File(path).exists()) {
-            progress_text.visibility = View.INVISIBLE
-            image_view.visibility = View.VISIBLE
-            image_view.setImage(ImageSource.uri(path))
-        } else {
+        val uri = page?.imagePath
+        if (uri == null) {
             page?.status = Page.ERROR
+            return
         }
+
+        val file = if (Build.VERSION.SDK_INT < 21 || UniFile.isFileUri(uri)) {
+            UniFile.fromFile(File(uri.path))
+        } else {
+            // Tree uri returns the root folder
+            UniFile.fromSingleUri(context, uri)
+        }!!
+        if (!file.exists()) {
+            page?.status = Page.ERROR
+            return
+        }
+
+        progress_text.visibility = View.INVISIBLE
+        image_view.visibility = View.VISIBLE
+        image_view.setImage(ImageSource.uri(file.uri))
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonReader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonReader.kt
@@ -116,7 +116,7 @@ class WebtoonReader : BaseReader() {
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        val savedPosition = pages.getOrNull(layoutManager.findFirstVisibleItemPosition())?.pageNumber ?: 0
+        val savedPosition = pages.getOrNull(layoutManager.findFirstVisibleItemPosition())?.index ?: 0
         outState.putInt(SAVED_POSITION, savedPosition)
         super.onSaveInstanceState(outState)
     }
@@ -163,7 +163,7 @@ class WebtoonReader : BaseReader() {
      * @param currentPage the initial page to display.
      */
     override fun onChapterSet(chapter: ReaderChapter, currentPage: Page) {
-        this.currentPage = currentPage.pageNumber
+        this.currentPage = currentPage.index
 
         // Make sure the view is already initialized.
         if (view != null) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent_updates/RecentChaptersPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent_updates/RecentChaptersPresenter.kt
@@ -261,7 +261,7 @@ class RecentChaptersPresenter : BasePresenter<RecentChaptersFragment>() {
      */
     private fun deleteChapter(chapter: RecentChapter) {
         val source = sourceManager.get(chapter.manga.source) ?: return
-        downloadManager.queue.del(chapter)
+        downloadManager.queue.remove(chapter)
         downloadManager.deleteChapter(source, chapter.manga, chapter)
         chapter.status = Download.NOT_DOWNLOADED
         chapter.download = null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent_updates/RecentChaptersPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent_updates/RecentChaptersPresenter.kt
@@ -222,10 +222,6 @@ class RecentChaptersPresenter : BasePresenter<RecentChaptersFragment>() {
      * @param chapters list of chapters
      */
     fun deleteChapters(chapters: List<RecentChapter>) {
-        val wasRunning = downloadManager.isRunning
-        if (wasRunning) {
-            DownloadService.stop(context)
-        }
         Observable.from(chapters)
                 .doOnNext { deleteChapter(it) }
                 .toList()
@@ -233,9 +229,6 @@ class RecentChaptersPresenter : BasePresenter<RecentChaptersFragment>() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeFirst({ view, result ->
                     view.onChaptersDeleted()
-                    if (wasRunning) {
-                        DownloadService.start(context)
-                    }
                 }, { view, error ->
                     view.onChaptersDeletedError(error)
                 })

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadsFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadsFragment.kt
@@ -96,6 +96,10 @@ class SettingsDownloadsFragment : SettingsFragment() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (data != null && requestCode == DOWNLOAD_DIR_CODE && resultCode == Activity.RESULT_OK) {
+            val uri = data.data
+            context.contentResolver.takePersistableUriPermission(uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+
             val file = UniFile.fromTreeUri(context, data.data)
             preferences.downloadsDirectory().set(file.uri.toString())
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadsFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadsFragment.kt
@@ -13,6 +13,7 @@ import android.support.v7.widget.RecyclerView
 import android.view.View
 import android.view.ViewGroup
 import com.afollestad.materialdialogs.MaterialDialog
+import com.hippo.unifile.UniFile
 import com.nononsenseapps.filepicker.AbstractFilePickerFragment
 import com.nononsenseapps.filepicker.FilePickerActivity
 import com.nononsenseapps.filepicker.FilePickerFragment
@@ -95,7 +96,8 @@ class SettingsDownloadsFragment : SettingsFragment() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (data != null && requestCode == DOWNLOAD_DIR_CODE && resultCode == Activity.RESULT_OK) {
-            preferences.downloadsDirectory().set(data.data.toString())
+            val file = UniFile.fromTreeUri(context, data.data)
+            preferences.downloadsDirectory().set(file.uri.toString())
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadsFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadsFragment.kt
@@ -97,8 +97,8 @@ class SettingsDownloadsFragment : SettingsFragment() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         when (requestCode) {
             DOWNLOAD_DIR_PRE_L -> if (data != null && resultCode == Activity.RESULT_OK) {
-                val file = UniFile.fromFile(File(data.data.path))
-                preferences.downloadsDirectory().set(file!!.uri.toString())
+                val uri = Uri.fromFile(File(data.data.path))
+                preferences.downloadsDirectory().set(uri.toString())
             }
             DOWNLOAD_DIR_L -> if (data != null && resultCode == Activity.RESULT_OK) {
                 val uri = data.data

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadsFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadsFragment.kt
@@ -108,7 +108,7 @@ class SettingsDownloadsFragment : SettingsFragment() {
                 @Suppress("NewApi")
                 context.contentResolver.takePersistableUriPermission(uri, flags)
 
-                val file = UniFile.fromTreeUri(context, data.data)
+                val file = UniFile.fromTreeUri(context, uri)
                 preferences.downloadsDirectory().set(file.uri.toString())
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ContextExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ContextExtensions.kt
@@ -1,10 +1,11 @@
 package eu.kanade.tachiyomi.util
 
-import android.app.AlarmManager
 import android.app.Notification
 import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.os.PowerManager
 import android.support.annotation.StringRes
 import android.support.v4.app.NotificationCompat
 import android.support.v4.content.ContextCompat
@@ -54,8 +55,13 @@ val Context.notificationManager: NotificationManager
     get() = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
 /**
- * Property to get the alarm manager from the context.
- * @return the alarm manager.
+ * Property to get the connectivity manager from the context.
  */
-val Context.alarmManager: AlarmManager
-    get() = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+val Context.connectivityManager: ConnectivityManager
+    get() = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+/**
+ * Property to get the power manager from the context.
+ */
+val Context.powerManager: PowerManager
+    get() = getSystemService(Context.POWER_SERVICE) as PowerManager

--- a/app/src/main/java/eu/kanade/tachiyomi/util/UrlUtil.java
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/UrlUtil.java
@@ -5,10 +5,6 @@ import java.net.URISyntaxException;
 
 public final class UrlUtil {
 
-    private static final String JPG = ".jpg";
-    private static final String PNG = ".png";
-    private static final String GIF = ".gif";
-
     private UrlUtil() throws InstantiationException {
         throw new InstantiationException("This class is not for instantiation");
     }
@@ -27,36 +23,4 @@ public final class UrlUtil {
         }
     }
 
-    public static boolean isJpg(String url) {
-        return containsIgnoreCase(url, JPG);
-    }
-
-    public static boolean isPng(String url) {
-        return containsIgnoreCase(url, PNG);
-    }
-
-    public static boolean isGif(String url) {
-        return containsIgnoreCase(url, GIF);
-    }
-
-    public static boolean containsIgnoreCase(String src, String what) {
-        final int length = what.length();
-        if (length == 0)
-            return true; // Empty string is contained
-
-        final char firstLo = Character.toLowerCase(what.charAt(0));
-        final char firstUp = Character.toUpperCase(what.charAt(0));
-
-        for (int i = src.length() - length; i >= 0; i--) {
-            // Quick check before calling the more expensive regionMatches() method:
-            final char ch = src.charAt(i);
-            if (ch != firstLo && ch != firstUp)
-                continue;
-
-            if (src.regionMatches(true, i, what, 0, length))
-                return true;
-        }
-
-        return false;
-    }
 }

--- a/app/src/main/res/raw/changelog_debug.xml
+++ b/app/src/main/res/raw/changelog_debug.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog bulletedList="false">
 
+    <changelogversion changeDate="" versionName="r959">
+        <changelogtext>The download manager has been rewritten and it's possible some of your downloads
+            aren't recognized anymore. You may have to check your downloads folder and manually delete those.
+        </changelogtext>
+        <changelogtext>You can now download to any folder in your SD card.</changelogtext>
+        <changelogtext>The download directory setting has been reset.</changelogtext>
+    </changelogversion>
+
     <changelogversion changeDate="" versionName="r857">
         <changelogtext>[b]Important![/b] Delete after read has been updated.
             This means the value has been reset set to disabled.

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -42,12 +42,11 @@
     <string name="pref_filter_downloaded_key">pref_filter_downloaded_key</string>
     <string name="pref_filter_unread_key">pref_filter_unread_key</string>
 
-    <string name="pref_download_directory_key">pref_download_directory_key</string>
+    <string name="pref_download_directory_key">download_directory</string>
     <string name="pref_download_slots_key">pref_download_slots_key</string>
     <string name="pref_remove_after_read_slots_key">remove_after_read_slots</string>
     <string name="pref_download_only_over_wifi_key">pref_download_only_over_wifi_key</string>
     <string name="pref_remove_after_marked_as_read_key">pref_remove_after_marked_as_read_key</string>
-    <string name="pref_category_remove_after_read_key">pref_category_remove_after_read_key</string>
     <string name="pref_last_used_category_key">last_used_category</string>
 
     <string name="pref_source_languages">pref_source_languages</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -355,5 +355,6 @@
     <string name="download_notifier_page_error">A page is missing in directory</string>
     <string name="download_notifier_page_ready_error">A page is not loaded</string>
     <string name="download_notifier_text_only_wifi">No wifi connection available</string>
+    <string name="download_notifier_no_network">No network connection available</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -350,7 +350,7 @@
     <string name="information_empty_library">Empty library</string>
 
     <!-- Download Notification -->
-    <string name="download_notifier_title_error">Error</string>
+    <string name="download_notifier_downloader_title">Downloader</string>
     <string name="download_notifier_unkown_error">An unexpected error occurred while downloading chapter</string>
     <string name="download_notifier_page_error">A page is missing in directory</string>
     <string name="download_notifier_page_ready_error">A page is not loaded</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -351,6 +351,7 @@
 
     <!-- Download Notification -->
     <string name="download_notifier_downloader_title">Downloader</string>
+    <string name="download_notifier_title_error">Error</string>
     <string name="download_notifier_unkown_error">An unexpected error occurred while downloading chapter</string>
     <string name="download_notifier_page_error">A page is missing in directory</string>
     <string name="download_notifier_page_ready_error">A page is not loaded</string>


### PR DESCRIPTION
**Compatibility with previously downloaded chapter isn't guaranteed.**

This rewrite fixes a few bugs and improves compatibility with newer Android versions, where `File` can't be used due to the security mechanisms introduced.

Download discovery performance was also improved due to the way the downloader works now. It downloads every file (which is stored with a `.tmp` extension) to a temporary directory `xxxx_tmp`. When the download is properly completed, the directory is renamed (the `_tmp is removed from the path`).
Thanks to that, a chapter can be marked as downloaded only checking if the directory exists, previously it had to parse the `index.json` file (which is not needed anymore) and analyze if all the pages were downloaded (this added a lot of overhead when a manga had a lot of downloaded chapters).

- [x] Allow to write to any folder in an external SD card (except in KitKat)
- [x] Replace `File` with `Uri` everywhere to use the Storage Access Framework.
- [x] Retain downloads after restarts. Closes #25
- [x] Titles ending with dots or spaces can't be downloaded. Fixes #511 
- [x] Downloader notification not being dismissed on errors. Fixes #527 (Not very tested though)
- [x] Removed the need of the `index.json` file
- [x] Better image extension discovery
- [x] Split `DownloadManager` in multiple classes.
- [x] Refactor the new `Downloader` class
- [x] Documentation
- [x] Test every API

