### PR TITLE
Add optional to automatically download new chapers

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -16,6 +16,7 @@ import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.download.DownloadService
 import eu.kanade.tachiyomi.data.library.LibraryUpdateService.Companion.start
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.preference.getOrDefault
@@ -272,6 +273,9 @@ class LibraryUpdateService : Service() {
                     if (newUpdates.isEmpty()) {
                         cancelNotification()
                     } else {
+                        if (preferences.downloadNew()) {
+                            DownloadService.start(this)
+                        }
                         showResultNotification(newUpdates, failedUpdates)
                     }
                 }
@@ -284,7 +288,6 @@ class LibraryUpdateService : Service() {
             mangaChapters.find { mangaChapter -> mangaChapter.url == it.url }!!
         }
         downloadManager.downloadChapters(manga, dbChapters)
-        downloadManager.startDownloads()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -89,6 +89,8 @@ class PreferenceKeys(context: Context) {
 
     val startScreen = context.getString(R.string.pref_start_screen_key)
 
+    val downloadNew = context.getString(R.string.pref_download_new_key)
+
     fun sourceUsername(sourceId: Int) = "pref_source_username_$sourceId"
 
     fun sourcePassword(sourceId: Int) = "pref_source_password_$sourceId"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -134,4 +134,6 @@ class PreferencesHelper(context: Context) {
 
     fun hiddenCatalogues() = rxPrefs.getStringSet("hidden_catalogues", emptySet())
 
+    fun downloadNew() = prefs.getBoolean(keys.downloadNew, false)
+
 }

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -65,6 +65,8 @@
     <string name="pref_display_catalogue_as_list">pref_display_catalogue_as_list</string>
     <string name="pref_last_catalogue_source_key">pref_last_catalogue_source_key</string>
 
+    <string name="pref_download_new_key">download_new</string>
+
     <!-- String Fonts -->
     <string name="font_roboto_medium">sans-serif</string>
     <string name="font_roboto_regular">sans-serif</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -166,6 +166,7 @@
     <string name="third_to_last">Third to last chapter</string>
     <string name="fourth_to_last">Fourth to last chapter</string>
     <string name="fifth_to_last">Fifth to last chapter</string>
+    <string name="pref_download_new">Download new chapters</string>
 
       <!-- Sync section -->
     <string name="services">Services</string>

--- a/app/src/main/res/xml/pref_downloads.xml
+++ b/app/src/main/res/xml/pref_downloads.xml
@@ -44,6 +44,15 @@
             android:summary="%s"
             android:title="@string/pref_remove_after_read" />
 
+        <PreferenceCategory
+            android:persistent="false"
+            android:title="@string/pref_download_new" />
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/pref_download_new_key"
+            android:title="@string/pref_download_new"/>
+
     </PreferenceScreen>
 
 </PreferenceScreen>


### PR DESCRIPTION
Fixes #116

The changed `readded` logic was needed to prevent all non-read chapters from sources such as MangaFox being detected as new