### PR TITLE
Implement language switcher

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -6,7 +6,6 @@ import android.content.res.Configuration
 import android.support.multidex.MultiDex
 import com.evernote.android.job.JobManager
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
-import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.updater.UpdateCheckerJob
 import eu.kanade.tachiyomi.util.LocaleHelper
 import org.acra.ACRA
@@ -14,9 +13,7 @@ import org.acra.annotation.ReportsCrashes
 import timber.log.Timber
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.InjektScope
-import uy.kohesive.injekt.injectLazy
 import uy.kohesive.injekt.registry.default.DefaultRegistrar
-import java.util.*
 
 @ReportsCrashes(
         formUri = "http://tachiyomi.kanade.eu/crash_report",

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -27,13 +27,6 @@ import java.util.*
 )
 open class App : Application() {
 
-    val preferences: PreferencesHelper by injectLazy()
-
-    //get lang code by pref
-    private val langCode by lazy {
-        LocaleHelper.intToLangCode(preferences.lang())
-    }
-
     override fun onCreate() {
         super.onCreate()
         Injekt = InjektScope(DefaultRegistrar())
@@ -44,8 +37,6 @@ open class App : Application() {
         setupAcra()
         setupJobManager()
 
-        //set language from preferences
-        LocaleHelper.setLocale(Locale(langCode))
         LocaleHelper.updateCfg(this, baseContext.resources.configuration)
     }
 
@@ -56,9 +47,9 @@ open class App : Application() {
         }
     }
 
-    override fun onConfigurationChanged(newConfig: Configuration?) {
+    override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        LocaleHelper.updateCfg(this, newConfig!!)
+        LocaleHelper.updateCfg(this, newConfig)
     }
 
     protected open fun setupAcra() {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -101,6 +101,6 @@ class PreferenceKeys(context: Context) {
 
     val libraryAsList = context.getString(R.string.pref_display_library_as_list)
 
-    val lang = context.getString(R.string.pref_language)
+    val lang = context.getString(R.string.pref_language_key)
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -101,4 +101,6 @@ class PreferenceKeys(context: Context) {
 
     val libraryAsList = context.getString(R.string.pref_display_library_as_list)
 
+    val lang = context.getString(R.string.pref_language)
+
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -138,4 +138,6 @@ class PreferencesHelper(context: Context) {
 
     fun downloadNew() = prefs.getBoolean(keys.downloadNew, false)
 
+    fun lang() = prefs.getInt(keys.lang, 0)
+
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseActivity.kt
@@ -1,9 +1,13 @@
 package eu.kanade.tachiyomi.ui.base.activity
 
 import android.support.v7.app.AppCompatActivity
+import eu.kanade.tachiyomi.util.LocaleHelper
 
 abstract class BaseActivity : AppCompatActivity(), ActivityMixin {
 
     override fun getActivity() = this
+    init {
+        LocaleHelper.updateCfg(this)
+    }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -110,6 +110,8 @@ class MainActivity : BaseActivity() {
             } else if (resultCode and SettingsActivity.FLAG_THEME_CHANGED != 0) {
                 // Delay activity recreation to avoid fragment leaks.
                 nav_view.post { recreate() }
+            } else if (resultCode and SettingsActivity.FLAG_LANG_CHANGED != 0) {
+                nav_view.post { recreate() }
             }
         } else {
             super.onActivityResult(requestCode, resultCode, data)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsActivity.kt
@@ -78,7 +78,7 @@ class SettingsActivity : BaseActivity(),
     companion object {
         const val FLAG_THEME_CHANGED = 0x1
         const val FLAG_DATABASE_CLEARED = 0x2
-        const val FLAG_LANG_CHANGED = 0x3
+        const val FLAG_LANG_CHANGED = 0x4
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsActivity.kt
@@ -78,6 +78,7 @@ class SettingsActivity : BaseActivity(),
     companion object {
         const val FLAG_THEME_CHANGED = 0x1
         const val FLAG_DATABASE_CLEARED = 0x2
+        const val FLAG_LANG_CHANGED = 0x3
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralFragment.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.util.LocaleHelper
 import eu.kanade.tachiyomi.util.plusAssign
 import eu.kanade.tachiyomi.widget.preference.IntListPreference
 import eu.kanade.tachiyomi.widget.preference.LibraryColumnsDialog
@@ -17,6 +18,7 @@ import net.xpece.android.support.preference.MultiSelectListPreference
 import rx.Observable
 import rx.android.schedulers.AndroidSchedulers
 import uy.kohesive.injekt.injectLazy
+import java.util.*
 
 class SettingsGeneralFragment : SettingsFragment(),
         PreferenceFragmentCompat.OnPreferenceDisplayDialogCallback {
@@ -43,6 +45,8 @@ class SettingsGeneralFragment : SettingsFragment(),
     val themePreference: IntListPreference by bindPref(R.string.pref_theme_key)
 
     val categoryUpdate: MultiSelectListPreference by bindPref(R.string.pref_library_update_categories_key)
+
+    val langPreference: IntListPreference by bindPref(R.string.pref_language)
 
     override fun onViewCreated(view: View, savedState: Bundle?) {
         super.onViewCreated(view, savedState)
@@ -101,6 +105,15 @@ class SettingsGeneralFragment : SettingsFragment(),
             activity.recreate()
             true
         }
+
+        langPreference.setOnPreferenceChangeListener { preference, newValue ->
+            (activity as SettingsActivity).parentFlags = SettingsActivity.FLAG_LANG_CHANGED
+            LocaleHelper.setLocale(Locale(LocaleHelper.intToLangCode(newValue.toString().toInt())))
+            LocaleHelper.updateCfg(activity.application, activity.baseContext.resources.configuration)
+            activity.recreate()
+            true
+        }
+
     }
 
     override fun onPreferenceDisplayDialog(p0: PreferenceFragmentCompat?, p: Preference): Boolean {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralFragment.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralFragment.kt
@@ -46,7 +46,7 @@ class SettingsGeneralFragment : SettingsFragment(),
 
     val categoryUpdate: MultiSelectListPreference by bindPref(R.string.pref_library_update_categories_key)
 
-    val langPreference: IntListPreference by bindPref(R.string.pref_language)
+    val langPreference: IntListPreference by bindPref(R.string.pref_language_key)
 
     override fun onViewCreated(view: View, savedState: Bundle?) {
         super.onViewCreated(view, savedState)

--- a/app/src/main/java/eu/kanade/tachiyomi/util/LocaleHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/LocaleHelper.kt
@@ -4,12 +4,15 @@ import android.app.Application
 import android.content.res.Configuration
 import android.os.Build
 import android.view.ContextThemeWrapper
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import uy.kohesive.injekt.injectLazy
 import java.util.Locale
 
 
 object LocaleHelper {
 
-    private lateinit var pLocale: Locale
+    private val preferences: PreferencesHelper by injectLazy()
+    private var pLocale = Locale(LocaleHelper.intToLangCode(preferences.lang()))
 
     fun setLocale(locale: Locale) {
         pLocale = locale
@@ -25,7 +28,7 @@ object LocaleHelper {
     }
 
     fun updateCfg(app: Application, config: Configuration){
-        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1){
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
             config.locale = pLocale
             app.baseContext.resources.updateConfiguration(config, app.baseContext.resources.displayMetrics)
         }
@@ -33,11 +36,11 @@ object LocaleHelper {
 
     fun intToLangCode(i: Int): String {
         return when(i){
-            0 -> ""
             1 -> "en"
             2 -> "es"
             3 -> "it"
             4 -> "pt"
+            // System Language
             else -> ""
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/LocaleHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/LocaleHelper.kt
@@ -1,0 +1,45 @@
+package eu.kanade.tachiyomi.util
+
+import android.app.Application
+import android.content.res.Configuration
+import android.os.Build
+import android.view.ContextThemeWrapper
+import java.util.Locale
+
+
+object LocaleHelper {
+
+    private lateinit var pLocale: Locale
+
+    fun setLocale(locale: Locale) {
+        pLocale = locale
+        Locale.setDefault(pLocale)
+    }
+
+    fun updateCfg(wrapper: ContextThemeWrapper) {
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1){
+            val config = Configuration()
+            config.setLocale(pLocale)
+            wrapper.applyOverrideConfiguration(config)
+        }
+    }
+
+    fun updateCfg(app: Application, config: Configuration){
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1){
+            config.locale = pLocale
+            app.baseContext.resources.updateConfiguration(config, app.baseContext.resources.displayMetrics)
+        }
+    }
+
+    fun intToLangCode(i: Int): String {
+        return when(i){
+            0 -> ""
+            1 -> "en"
+            2 -> "es"
+            3 -> "it"
+            4 -> "pt"
+            else -> ""
+        }
+    }
+
+}

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -188,4 +188,20 @@
         <item>2</item>
     </string-array>
 
+    <string-array name="languages">
+        <item>@string/system_default</item>
+        <item>@string/english</item>
+        <item>@string/spanish</item>
+        <item>@string/italian</item>
+        <item>@string/portuguese</item>
+    </string-array>
+
+    <string-array name="languages_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -22,6 +22,7 @@
     <string name="pref_library_update_restriction_key">library_update_restriction</string>
     <string name="pref_start_screen_key">start_screen</string>
     <string name="pref_language">language</string>
+    <string name="pref_language_key">language</string>
 
     <string name="pref_default_viewer_key">pref_default_viewer_key</string>
     <string name="pref_image_scale_type_key">pref_image_scale_type_key</string>

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -21,6 +21,7 @@
     <string name="pref_theme_key">pref_theme_key</string>
     <string name="pref_library_update_restriction_key">library_update_restriction</string>
     <string name="pref_start_screen_key">start_screen</string>
+    <string name="pref_language">pref_language</string>
 
     <string name="pref_default_viewer_key">pref_default_viewer_key</string>
     <string name="pref_image_scale_type_key">pref_image_scale_type_key</string>

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -21,7 +21,6 @@
     <string name="pref_theme_key">pref_theme_key</string>
     <string name="pref_library_update_restriction_key">library_update_restriction</string>
     <string name="pref_start_screen_key">start_screen</string>
-    <string name="pref_language">language</string>
     <string name="pref_language_key">language</string>
 
     <string name="pref_default_viewer_key">pref_default_viewer_key</string>

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -21,7 +21,7 @@
     <string name="pref_theme_key">pref_theme_key</string>
     <string name="pref_library_update_restriction_key">library_update_restriction</string>
     <string name="pref_start_screen_key">start_screen</string>
-    <string name="pref_language">pref_language</string>
+    <string name="pref_language">language</string>
 
     <string name="pref_default_viewer_key">pref_default_viewer_key</string>
     <string name="pref_image_scale_type_key">pref_image_scale_type_key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="light_theme">Main theme</string>
     <string name="dark_theme">Dark theme</string>
     <string name="pref_start_screen">Start screen</string>
+    <string name="pref_language">Language</string>
 
       <!-- Languages -->
     <string name="system_default">System Default</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,13 @@
     <string name="dark_theme">Dark theme</string>
     <string name="pref_start_screen">Start screen</string>
 
+      <!-- Languages -->
+    <string name="system_default">System Default</string>
+    <string name="english">English</string>
+    <string name="spanish">Spanish</string>
+    <string name="italian">Italian</string>
+    <string name="portuguese">Portuguese</string>
+
       <!-- Reader section -->
     <string name="pref_fullscreen">Fullscreen</string>
     <string name="pref_lock_orientation">Lock orientation</string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -56,6 +56,14 @@
             android:key="@string/pref_update_only_non_completed_key"
             android:title="@string/pref_update_only_non_completed" />
 
+        <eu.kanade.tachiyomi.widget.preference.IntListPreference
+            android:defaultValue="0"
+            android:entries="@array/languages"
+            android:entryValues="@array/languages_values"
+            android:key="pref_language"
+            android:summary="%s"
+            android:title="Language" />
+
     </PreferenceScreen>
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -60,7 +60,7 @@
             android:defaultValue="0"
             android:entries="@array/languages"
             android:entryValues="@array/languages_values"
-            android:key="language"
+            android:key="@string/pref_language_key"
             android:summary="%s"
             android:title="Language" />
 

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -62,7 +62,7 @@
             android:entryValues="@array/languages_values"
             android:key="@string/pref_language_key"
             android:summary="%s"
-            android:title="Language" />
+            android:title="@string/pref_language" />
 
     </PreferenceScreen>
 

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -60,7 +60,7 @@
             android:defaultValue="0"
             android:entries="@array/languages"
             android:entryValues="@array/languages_values"
-            android:key="pref_language"
+            android:key="language"
             android:summary="%s"
             android:title="Language" />
 


### PR DESCRIPTION
Implements request #558 

In my opinion I don't think it's that much of a mess. There are two deprecated java functions used, these cannot be changed unless the min android API is set to 17 instead of 16.

Feel free to point out any changes needed or just close if this isn't something you want.