### PR TITLE
Using title instead of text for Mangahere titles

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/source/online/english/Mangahere.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/source/online/english/Mangahere.kt
@@ -33,7 +33,7 @@ class Mangahere(override val id: Int) : ParsedOnlineSource() {
     override fun popularMangaFromElement(element: Element, manga: Manga) {
         element.select("div.title > a").first().let {
             manga.setUrlWithoutDomain(it.attr("href"))
-            manga.title = it.text()
+            manga.title = it.attr("title")
         }
     }
 
@@ -52,7 +52,7 @@ class Mangahere(override val id: Int) : ParsedOnlineSource() {
     override fun searchMangaFromElement(element: Element, manga: Manga) {
         element.select("a.manga_info").first().let {
             manga.setUrlWithoutDomain(it.attr("href"))
-            manga.title = it.text()
+            manga.title = it.attr("title")
         }
     }
 


### PR DESCRIPTION
Fixes #571
The text on the popular manga page of Mangahere contains escaped HTML characters. The title attributes of the links do not contain them.