### PR TITLE
Local manga in zip/cbz/folder format

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,6 +179,9 @@ dependencies {
     // Crash reports
     compile 'ch.acra:acra:4.9.2'
 
+    // Sort
+    compile 'com.github.gpanther:java-nat-sort:natural-comparator-1.1'
+
     // UI
     compile 'com.dmitrymalkovich.android:material-design-dimens:1.4'
     compile 'com.github.dmytrodanylyk.android-process-button:library:1.0.4'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,6 +76,11 @@
                 android:resource="@xml/provider_paths" />
         </provider>
 
+        <provider
+            android:name="eu.kanade.tachiyomi.util.ZipContentProvider"
+            android:authorities="${applicationId}.zip-provider"
+            android:exported="false"></provider>
+
         <receiver
             android:name=".data.notification.NotificationReceiver"
             android:exported="false" />

--- a/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaModelLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaModelLoader.kt
@@ -89,8 +89,8 @@ class MangaModelLoader(context: Context) : StreamModelLoader<Manga> {
             return null
         }
 
-        if (url!!.startsWith("file:/"))
-            return FileLoader(baseFileLoader).getResourceFetcher(File(url.substring(6)), width, height)
+        if (url!!.startsWith("file://"))
+            return FileLoader(baseFileLoader).getResourceFetcher(File(url.substring(7)), width, height)
 
         // Obtain the request url and the file for this url from the LRU cache, or calculate it
         // and add them to the cache.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaModelLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaModelLoader.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.data.glide
 
 import android.content.Context
+import android.net.Uri
 import android.util.LruCache
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.data.DataFetcher
@@ -44,6 +45,12 @@ class MangaModelLoader(context: Context) : StreamModelLoader<Manga> {
             InputStream::class.java, context)
 
     /**
+     * Base file loader.
+     */
+    private val baseFileLoader = Glide.buildModelLoader(Uri::class.java,
+            InputStream::class.java, context)
+
+    /**
      * LRU cache whose key is the thumbnail url of the manga, and the value contains the request url
      * and the file where it should be stored in case the manga is a favorite.
      */
@@ -81,6 +88,9 @@ class MangaModelLoader(context: Context) : StreamModelLoader<Manga> {
         if (url.isNullOrEmpty()) {
             return null
         }
+
+        if (url!!.startsWith("file:/"))
+            return FileLoader(baseFileLoader).getResourceFetcher(File(url.substring(6)), width, height)
 
         // Obtain the request url and the file for this url from the LRU cache, or calculate it
         // and add them to the cache.

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -10,14 +10,16 @@ import eu.kanade.tachiyomi.util.ZipContentProvider
 import net.greypanther.natsort.CaseInsensitiveSimpleNaturalComparator
 import rx.Observable
 import java.io.File
+import java.net.URLConnection
 import java.util.*
+import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
 class LocalSource(private val context: Context) : CatalogueSource {
-    private class OrderBy() : Filter.Sort("Order by", arrayOf("Title", "Date"), Filter.Sort.Selection(1, false))
+    private class OrderBy() : Filter.Sort("Order by", arrayOf("Title", "Date"), Filter.Sort.Selection(0, true))
 
     private val fileProtocol = "file://"
-    private fun isImage(name: String) = name.endsWith(".jpg", true) || name.endsWith(".jpeg", true) || name.endsWith(".png", true) || name.endsWith(".gif", true)
+    private fun isImage(name: String) = URLConnection.guessContentTypeFromName(name).orEmpty().startsWith("image/")
 
     override val id = 0L;
     override val name = "LocalSource"
@@ -49,13 +51,16 @@ class LocalSource(private val context: Context) : CatalogueSource {
         if (chapFile.isDirectory)
             return Observable.just(chapFile.listFiles()
                     .filter { !it.isDirectory && isImage(it.name) }
-                    .sortedWith(Comparator<File> { t1, t2 -> CaseInsensitiveSimpleNaturalComparator.getInstance<String>().compare(t1.nameWithoutExtension, t2.nameWithoutExtension) })
+                    .sortedWith(Comparator<File> { t1, t2 -> CaseInsensitiveSimpleNaturalComparator.getInstance<String>().compare(t1.name, t2.name) })
                     .mapIndexed { i, v -> Page(i, fileProtocol + v.absolutePath, fileProtocol + v.absolutePath, Uri.fromFile(v)).apply { status = Page.READY } })
         else
             return Observable.just(ZipFile(chapFile).entries().toList()
-                    .filter { !it.isDirectory && isImage(it.name) }.map { entry ->
-                "content://${ZipContentProvider.PROVIDER}${chapFile.absolutePath}!/${entry.name}"
-            }.mapIndexed { i, v -> Page(i, v, v, Uri.parse(v)).apply { status = Page.READY } })
+                    .filter { !it.isDirectory && isImage(it.name) }
+                    .sortedWith(Comparator<ZipEntry> { t1, t2 -> CaseInsensitiveSimpleNaturalComparator.getInstance<String>().compare(t1.name, t2.name) })
+                    .mapIndexed { i, v ->
+                        val path = "content://${ZipContentProvider.PROVIDER}${chapFile.absolutePath}!/${v.name}"
+                        Page(i, path, path, Uri.parse(path)).apply { status = Page.READY }
+                    })
     }
 
     override fun fetchPopularManga(page: Int) = fetchSearchManga(page, "", getFilterList())

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -46,8 +46,8 @@ class LocalSource(private val context: Context) : CatalogueSource {
         }
 
         private fun getBaseDirectories(context: Context): List<File> {
-            return DiskUtil.getExternalStorages(context)
-                    .map { File("${it.absolutePath}/Tachiyomi/local") }
+            val c = File.separator + context.getString(R.string.app_name) + File.separator + "local"
+            return DiskUtil.getExternalStorages(context).map { File(it.absolutePath + c) }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -5,10 +5,10 @@ import android.net.Uri
 import android.os.Environment
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.source.model.*
+import eu.kanade.tachiyomi.util.ChapterRecognition
 import net.greypanther.natsort.CaseInsensitiveSimpleNaturalComparator
 import rx.Observable
 import java.util.*
-import java.util.regex.Pattern
 import java.util.zip.ZipInputStream
 import java.io.*
 
@@ -16,7 +16,6 @@ class LocalSource(private val context: Context) : CatalogueSource {
     private class OrderBy() : Filter.Sort("Order by", arrayOf("Title", "Date"), Filter.Sort.Selection(1, false))
 
     private val fileProtocol = "file://"
-    private val floatPattern = Pattern.compile("[0-9]+[.]?[0-9]*")
     private fun isImage(name: String) = name.endsWith(".jpg", true) || name.endsWith(".jpeg", true) || name.endsWith(".png", true) || name.endsWith(".gif", true)
 
     override val id = 0L;
@@ -38,11 +37,7 @@ class LocalSource(private val context: Context) : CatalogueSource {
                         val chapNameCut = chapName.replace(manga.title, "", true)
                         name = if (chapNameCut.isEmpty()) chapName else chapNameCut
                         date_upload = chapterFile.lastModified()
-                        var chapNum = "0"
-                        val matcher = floatPattern.matcher(name)
-                        while (matcher.find())
-                            chapNum = matcher.group()
-                        chapter_number = chapNum.toFloat()
+                        ChapterRecognition.parseChapterNumber(this, manga)
                     }
                 }
         return Observable.just(chapters.sortedByDescending { it.chapter_number })

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -1,0 +1,138 @@
+package eu.kanade.tachiyomi.source
+
+import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.source.model.*
+import net.greypanther.natsort.CaseInsensitiveSimpleNaturalComparator
+import rx.Observable
+import java.util.*
+import java.util.regex.Pattern
+import java.util.zip.ZipInputStream
+import java.io.*
+
+class LocalSource(private val context: Context) : CatalogueSource {
+    private class OrderBy() : Filter.Sort("Order by", arrayOf("Title", "Date"), Filter.Sort.Selection(1, false))
+
+    private val fileProtocol = "file:/"
+    private val floatPattern = Pattern.compile("[0-9]+[.]?[0-9]*")
+    private fun isImage(name: String) = name.endsWith(".jpg", true) || name.endsWith(".jpeg", true) || name.endsWith(".png", true) || name.endsWith(".gif", true)
+
+    override val id = 0L;
+    override val name = "LocalSource"
+    override val lang = "en"
+    override val supportsLatest = false
+
+    override fun toString() = context.getString(R.string.local_source)
+
+    override fun fetchMangaDetails(manga: SManga) = Observable.from(arrayOf(manga))
+
+    override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
+        val chapters = File(manga.url.substring((6))).listFiles()
+                .filter { it.isDirectory || it.extension.equals("zip", true) || it.extension.equals("cbz", true) }
+                .map { chapterFile ->
+                    SChapter.create().apply {
+                        url = fileProtocol + chapterFile.absolutePath
+                        val chapName = if (chapterFile.isDirectory) chapterFile.name else chapterFile.nameWithoutExtension
+                        val chapNameCut = chapName.replace(manga.title, "", true)
+                        name = if (chapNameCut.isEmpty()) chapName else chapNameCut
+                        date_upload = chapterFile.lastModified()
+                        var chapNum = "0"
+                        val matcher = floatPattern.matcher(name)
+                        while (matcher.find())
+                            chapNum = matcher.group()
+                        chapter_number = chapNum.toFloat()
+                    }
+                }
+        return Observable.from(arrayOf(chapters.sortedByDescending { it.chapter_number }))
+    }
+
+    override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
+        val chapFile = File(chapter.url.substring(6))
+        val pages: List<Page>
+        if (chapFile.isDirectory) {
+            pages = chapFile.listFiles()
+                    .filter { !it.isDirectory && isImage(it.name) }
+                    .sortedWith(Comparator<File> { t1, t2 -> CaseInsensitiveSimpleNaturalComparator.getInstance<String>().compare(t1.nameWithoutExtension, t2.nameWithoutExtension) })
+                    .withIndex().mapIndexed { i, v -> Page(i, v.value.absolutePath, v.value.absolutePath, Uri.fromFile(v.value)).apply { status = Page.READY } }
+        } else {
+            val destDir = File(context.cacheDir.absolutePath + File.separator + chapFile.path.replace(File.separator, "_"))
+            if (!destDir.exists())
+                destDir.mkdir()
+
+            val images = ArrayList<Pair<String, Uri>>()
+            val zipIn = ZipInputStream(FileInputStream(chapFile))
+            var entry = zipIn.nextEntry
+            while (entry != null) {
+                val filePath = destDir.absolutePath + File.separator + entry.name
+                val file = File(filePath)
+                if (entry.isDirectory) {
+                    if (!file.exists())
+                        file.mkdir()
+                } else if (isImage(entry.name)) {
+                    images.add(Pair(entry.name, Uri.fromFile(file)))
+                    if (!file.exists()) {
+                        val bos = BufferedOutputStream(FileOutputStream(filePath))
+                        val bytesIn = ByteArray(4096)
+                        var read: Int
+                        while (true) {
+                            read = zipIn.read(bytesIn)
+                            if (read == -1) break;
+                            bos.write(bytesIn, 0, read)
+                        }
+                        bos.close()
+                    }
+                }
+                zipIn.closeEntry()
+                entry = zipIn.nextEntry
+            }
+            zipIn.close()
+            pages = images.sortedWith(Comparator<Pair<String, Uri>> { t1, t2 -> CaseInsensitiveSimpleNaturalComparator.getInstance<String>().compare(t1.first, t2.first) })
+                    .mapIndexed { i, v -> Page(i, chapter.url + "!" + v.first, chapter.url + "!" + v.first, v.second).apply { status = Page.READY } }
+        }
+        return Observable.from(arrayOf(pages))
+    }
+
+    override fun fetchPopularManga(page: Int) = fetchSearchManga(page, "", getFilterList())
+
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        val mangaBaseDir = File(Environment.getExternalStorageDirectory().absolutePath +
+                File.separator + context.getString(R.string.app_name), "mangas")
+        var mangaDirs = mangaBaseDir.listFiles()
+                .filter { it.isDirectory && it.name.contains(query, true) }
+        if (!filters.isEmpty()) {
+            val state = (filters.get(0) as OrderBy).state
+            when (state?.index) {
+                0 -> {
+                    if (state!!.ascending)
+                        mangaDirs = mangaDirs.sortedBy { it.name.toLowerCase(Locale.ENGLISH) }
+                    else
+                        mangaDirs = mangaDirs.sortedByDescending { it.name.toLowerCase(Locale.ENGLISH) }
+                }
+                1 -> {
+                    if (state!!.ascending)
+                        mangaDirs = mangaDirs.sortedBy { it.lastModified() }
+                    else
+                        mangaDirs = mangaDirs.sortedByDescending { it.lastModified() }
+                }
+            }
+        }
+        val mangas = mangaDirs.map { mangaDir ->
+            SManga.create().apply {
+                title = mangaDir.name
+                url = fileProtocol + mangaDir.absolutePath
+                val coverPath = mangaDir.absolutePath + File.separator + "cover.jpg"
+                if (File(coverPath).exists()) thumbnail_url = fileProtocol + coverPath
+                initialized = true
+            }
+        }
+        return Observable.from(arrayOf(MangasPage(mangas, false)))
+    }
+
+    override fun fetchLatestUpdates(page: Int): Observable<MangasPage> {
+        throw UnsupportedOperationException("not implemented")
+    }
+
+    override fun getFilterList() = FilterList(OrderBy())
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -15,7 +15,7 @@ import java.io.*
 class LocalSource(private val context: Context) : CatalogueSource {
     private class OrderBy() : Filter.Sort("Order by", arrayOf("Title", "Date"), Filter.Sort.Selection(1, false))
 
-    private val fileProtocol = "file:/"
+    private val fileProtocol = "file://"
     private val floatPattern = Pattern.compile("[0-9]+[.]?[0-9]*")
     private fun isImage(name: String) = name.endsWith(".jpg", true) || name.endsWith(".jpeg", true) || name.endsWith(".png", true) || name.endsWith(".gif", true)
 
@@ -26,10 +26,10 @@ class LocalSource(private val context: Context) : CatalogueSource {
 
     override fun toString() = context.getString(R.string.local_source)
 
-    override fun fetchMangaDetails(manga: SManga) = Observable.from(arrayOf(manga))
+    override fun fetchMangaDetails(manga: SManga) = Observable.just(manga)
 
     override fun fetchChapterList(manga: SManga): Observable<List<SChapter>> {
-        val chapters = File(manga.url.substring((6))).listFiles()
+        val chapters = File(manga.url.substring((7))).listFiles()
                 .filter { it.isDirectory || it.extension.equals("zip", true) || it.extension.equals("cbz", true) }
                 .map { chapterFile ->
                     SChapter.create().apply {
@@ -45,17 +45,17 @@ class LocalSource(private val context: Context) : CatalogueSource {
                         chapter_number = chapNum.toFloat()
                     }
                 }
-        return Observable.from(arrayOf(chapters.sortedByDescending { it.chapter_number }))
+        return Observable.just(chapters.sortedByDescending { it.chapter_number })
     }
 
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
-        val chapFile = File(chapter.url.substring(6))
+        val chapFile = File(chapter.url.substring(7))
         val pages: List<Page>
         if (chapFile.isDirectory) {
             pages = chapFile.listFiles()
                     .filter { !it.isDirectory && isImage(it.name) }
                     .sortedWith(Comparator<File> { t1, t2 -> CaseInsensitiveSimpleNaturalComparator.getInstance<String>().compare(t1.nameWithoutExtension, t2.nameWithoutExtension) })
-                    .withIndex().mapIndexed { i, v -> Page(i, v.value.absolutePath, v.value.absolutePath, Uri.fromFile(v.value)).apply { status = Page.READY } }
+                    .mapIndexed { i, v -> Page(i, fileProtocol + v.absolutePath, fileProtocol + v.absolutePath, Uri.fromFile(v)).apply { status = Page.READY } }
         } else {
             val destDir = File(context.cacheDir.absolutePath + File.separator + chapFile.path.replace(File.separator, "_"))
             if (!destDir.exists())
@@ -91,31 +91,29 @@ class LocalSource(private val context: Context) : CatalogueSource {
             pages = images.sortedWith(Comparator<Pair<String, Uri>> { t1, t2 -> CaseInsensitiveSimpleNaturalComparator.getInstance<String>().compare(t1.first, t2.first) })
                     .mapIndexed { i, v -> Page(i, chapter.url + "!" + v.first, chapter.url + "!" + v.first, v.second).apply { status = Page.READY } }
         }
-        return Observable.from(arrayOf(pages))
+        return Observable.just(pages)
     }
 
     override fun fetchPopularManga(page: Int) = fetchSearchManga(page, "", getFilterList())
 
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         val mangaBaseDir = File(Environment.getExternalStorageDirectory().absolutePath +
-                File.separator + context.getString(R.string.app_name), "mangas")
+                File.separator + context.getString(R.string.app_name), "local")
         var mangaDirs = mangaBaseDir.listFiles()
                 .filter { it.isDirectory && it.name.contains(query, true) }
-        if (!filters.isEmpty()) {
-            val state = (filters.get(0) as OrderBy).state
-            when (state?.index) {
-                0 -> {
-                    if (state!!.ascending)
-                        mangaDirs = mangaDirs.sortedBy { it.name.toLowerCase(Locale.ENGLISH) }
-                    else
-                        mangaDirs = mangaDirs.sortedByDescending { it.name.toLowerCase(Locale.ENGLISH) }
-                }
-                1 -> {
-                    if (state!!.ascending)
-                        mangaDirs = mangaDirs.sortedBy { it.lastModified() }
-                    else
-                        mangaDirs = mangaDirs.sortedByDescending { it.lastModified() }
-                }
+        val state = ((if (filters.isEmpty()) getFilterList() else filters).get(0) as OrderBy).state
+        when (state?.index) {
+            0 -> {
+                if (state!!.ascending)
+                    mangaDirs = mangaDirs.sortedBy { it.name.toLowerCase(Locale.ENGLISH) }
+                else
+                    mangaDirs = mangaDirs.sortedByDescending { it.name.toLowerCase(Locale.ENGLISH) }
+            }
+            1 -> {
+                if (state!!.ascending)
+                    mangaDirs = mangaDirs.sortedBy { it.lastModified() }
+                else
+                    mangaDirs = mangaDirs.sortedByDescending { it.lastModified() }
             }
         }
         val mangas = mangaDirs.map { mangaDir ->

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -6,11 +6,12 @@ import android.os.Environment
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.source.model.*
 import eu.kanade.tachiyomi.util.ChapterRecognition
+import eu.kanade.tachiyomi.util.ZipContentProvider
 import net.greypanther.natsort.CaseInsensitiveSimpleNaturalComparator
 import rx.Observable
+import java.io.File
 import java.util.*
-import java.util.zip.ZipInputStream
-import java.io.*
+import java.util.zip.ZipFile
 
 class LocalSource(private val context: Context) : CatalogueSource {
     private class OrderBy() : Filter.Sort("Order by", arrayOf("Title", "Date"), Filter.Sort.Selection(1, false))
@@ -45,48 +46,16 @@ class LocalSource(private val context: Context) : CatalogueSource {
 
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
         val chapFile = File(chapter.url.substring(7))
-        val pages: List<Page>
-        if (chapFile.isDirectory) {
-            pages = chapFile.listFiles()
+        if (chapFile.isDirectory)
+            return Observable.just(chapFile.listFiles()
                     .filter { !it.isDirectory && isImage(it.name) }
                     .sortedWith(Comparator<File> { t1, t2 -> CaseInsensitiveSimpleNaturalComparator.getInstance<String>().compare(t1.nameWithoutExtension, t2.nameWithoutExtension) })
-                    .mapIndexed { i, v -> Page(i, fileProtocol + v.absolutePath, fileProtocol + v.absolutePath, Uri.fromFile(v)).apply { status = Page.READY } }
-        } else {
-            val destDir = File(context.cacheDir.absolutePath + File.separator + chapFile.path.replace(File.separator, "_"))
-            if (!destDir.exists())
-                destDir.mkdir()
-
-            val images = ArrayList<Pair<String, Uri>>()
-            val zipIn = ZipInputStream(FileInputStream(chapFile))
-            var entry = zipIn.nextEntry
-            while (entry != null) {
-                val filePath = destDir.absolutePath + File.separator + entry.name
-                val file = File(filePath)
-                if (entry.isDirectory) {
-                    if (!file.exists())
-                        file.mkdir()
-                } else if (isImage(entry.name)) {
-                    images.add(Pair(entry.name, Uri.fromFile(file)))
-                    if (!file.exists()) {
-                        val bos = BufferedOutputStream(FileOutputStream(filePath))
-                        val bytesIn = ByteArray(4096)
-                        var read: Int
-                        while (true) {
-                            read = zipIn.read(bytesIn)
-                            if (read == -1) break;
-                            bos.write(bytesIn, 0, read)
-                        }
-                        bos.close()
-                    }
-                }
-                zipIn.closeEntry()
-                entry = zipIn.nextEntry
-            }
-            zipIn.close()
-            pages = images.sortedWith(Comparator<Pair<String, Uri>> { t1, t2 -> CaseInsensitiveSimpleNaturalComparator.getInstance<String>().compare(t1.first, t2.first) })
-                    .mapIndexed { i, v -> Page(i, chapter.url + "!" + v.first, chapter.url + "!" + v.first, v.second).apply { status = Page.READY } }
-        }
-        return Observable.just(pages)
+                    .mapIndexed { i, v -> Page(i, fileProtocol + v.absolutePath, fileProtocol + v.absolutePath, Uri.fromFile(v)).apply { status = Page.READY } })
+        else
+            return Observable.just(ZipFile(chapFile).entries().toList()
+                    .filter { !it.isDirectory && isImage(it.name) }.map { entry ->
+                "content://${ZipContentProvider.PROVIDER}${chapFile.absolutePath}!/${entry.name}"
+            }.mapIndexed { i, v -> Page(i, v, v, Uri.parse(v)).apply { status = Page.READY } })
     }
 
     override fun fetchPopularManga(page: Int) = fetchSearchManga(page, "", getFilterList())

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
@@ -48,6 +48,7 @@ open class SourceManager(private val context: Context) {
     }
 
     private fun createInternalSources(): List<Source> = listOf(
+            LocalSource(context),
             Batoto(),
             Mangahere(),
             Mangafox(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -13,6 +13,7 @@ import eu.kanade.tachiyomi.data.database.models.MangaCategory
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.preference.getOrDefault
+import eu.kanade.tachiyomi.source.LocalSource
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.ui.base.presenter.BasePresenter
 import eu.kanade.tachiyomi.util.combineLatest
@@ -345,6 +346,11 @@ class LibraryPresenter : BasePresenter<LibraryFragment>() {
      */
     @Throws(IOException::class)
     fun editCoverWithStream(inputStream: InputStream, manga: Manga): Boolean {
+        if (manga.source == LocalSource.ID) {
+            LocalSource.updateCover(manga, inputStream)
+            return true
+        }
+
         if (manga.thumbnail_url != null && manga.favorite) {
             coverCache.copyToCache(manga.thumbnail_url!!, inputStream)
             return true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -15,6 +15,7 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.track.TrackManager
 import eu.kanade.tachiyomi.data.track.TrackUpdateService
+import eu.kanade.tachiyomi.source.LocalSource
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
@@ -539,6 +540,12 @@ class ReaderPresenter : BasePresenter<ReaderActivity>() {
      */
     internal fun setImageAsCover(page: Page) {
         try {
+            if (manga.source == LocalSource.ID) {
+                LocalSource.updateCover(manga, page.url, context)
+                context.toast(R.string.cover_updated)
+                return
+            }
+
             val thumbUrl = manga.thumbnail_url ?: throw Exception("Image url not found")
             if (manga.favorite) {
                 val input = context.contentResolver.openInputStream(page.uri)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recently_read/RecentlyReadHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recently_read/RecentlyReadHolder.kt
@@ -50,7 +50,7 @@ class RecentlyReadHolder(view: View, private val adapter: RecentlyReadAdapter)
         // Set source + chapter title
         val formattedNumber = decimalFormat.format(chapter.chapter_number.toDouble())
         itemView.manga_source.text = itemView.context.getString(R.string.recent_manga_source)
-                .format(adapter.sourceManager.get(manga.source)?.name, formattedNumber)
+                .format(adapter.sourceManager.get(manga.source)?.toString(), formattedNumber)
 
         // Set last read timestamp title
         itemView.last_read.text = df.format(Date(history.last_read))

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.kt
@@ -1,7 +1,7 @@
 package eu.kanade.tachiyomi.util
 
-import eu.kanade.tachiyomi.data.database.models.Chapter
-import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
 
 /**
  * -R> = regex conversion.
@@ -37,7 +37,7 @@ object ChapterRecognition {
      */
     private val unwantedWhiteSpace = Regex("""(\s)(extra|special|omake)""")
 
-    fun parseChapterNumber(chapter: Chapter, manga: Manga) {
+    fun parseChapterNumber(chapter: SChapter, manga: SManga) {
         // If chapter number is known return.
         if (chapter.chapter_number == -2f || chapter.chapter_number > -1f)
             return
@@ -91,7 +91,7 @@ object ChapterRecognition {
      * @param chapter chapter object
      * @return true if volume is found
      */
-    fun updateChapter(match: MatchResult?, chapter: Chapter): Boolean {
+    fun updateChapter(match: MatchResult?, chapter: SChapter): Boolean {
         match?.let {
             val initial = it.groups[1]?.value?.toFloat()!!
             val subChapterDecimal = it.groups[2]?.value

--- a/app/src/main/java/eu/kanade/tachiyomi/util/DiskUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/DiskUtil.kt
@@ -9,7 +9,7 @@ import java.security.NoSuchAlgorithmException
 object DiskUtil {
 
     fun isImage(name: String, openStream: (() -> InputStream)? = null): Boolean {
-        var contentType = URLConnection.guessContentTypeFromName(name)
+        val contentType = URLConnection.guessContentTypeFromName(name)
         if (contentType != null)
             return contentType.startsWith("image/")
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ZipContentProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ZipContentProvider.kt
@@ -6,13 +6,12 @@ import android.content.res.AssetFileDescriptor
 import android.database.Cursor
 import android.net.Uri
 import android.os.ParcelFileDescriptor
-import android.webkit.MimeTypeMap
 import eu.kanade.tachiyomi.BuildConfig
 import timber.log.Timber
 import java.io.IOException
 import java.net.URL
+import java.net.URLConnection
 import java.util.concurrent.Executors
-import kotlin.concurrent.thread
 
 class ZipContentProvider : ContentProvider() {
 
@@ -27,8 +26,7 @@ class ZipContentProvider : ContentProvider() {
     }
 
     override fun getType(uri: Uri): String? {
-        val ext = MimeTypeMap.getFileExtensionFromUrl(uri.toString())
-        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext)
+        return URLConnection.guessContentTypeFromName(uri.toString())
     }
 
     override fun openAssetFile(uri: Uri, mode: String): AssetFileDescriptor? {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ZipContentProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ZipContentProvider.kt
@@ -1,0 +1,69 @@
+package eu.kanade.tachiyomi.util
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.res.AssetFileDescriptor
+import android.database.Cursor
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.webkit.MimeTypeMap
+import eu.kanade.tachiyomi.BuildConfig
+import java.io.IOException
+import java.net.URL
+import kotlin.concurrent.thread
+
+class ZipContentProvider : ContentProvider() {
+
+    companion object {
+        const val PROVIDER = "${BuildConfig.APPLICATION_ID}.zip-provider"
+    }
+
+    override fun onCreate(): Boolean {
+        return true
+    }
+
+    override fun getType(uri: Uri): String? {
+        val ext = MimeTypeMap.getFileExtensionFromUrl(uri.toString())
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext)
+    }
+
+    override fun openAssetFile(uri: Uri, mode: String): AssetFileDescriptor? {
+        try {
+            val url = "jar:file://" + uri.toString().substringAfter("content://$PROVIDER")
+            val input = URL(url).openStream()
+            val pipe = ParcelFileDescriptor.createPipe()
+            thread {
+                val output = ParcelFileDescriptor.AutoCloseOutputStream(pipe[1])
+                input.use {
+                    output.use {
+                        try {
+                            input.copyTo(output)
+                        } catch (e: IOException) {
+                            e.printStackTrace()
+                        }
+                        output.flush()
+                    }
+                }
+            }
+            return AssetFileDescriptor(pipe[0], 0, -1)
+        } catch (e: IOException) {
+            return null
+        }
+    }
+
+    override fun insert(p0: Uri?, p1: ContentValues?): Uri {
+        throw UnsupportedOperationException("not implemented")
+    }
+
+    override fun query(p0: Uri?, p1: Array<out String>?, p2: String?, p3: Array<out String>?, p4: String?): Cursor {
+        throw UnsupportedOperationException("not implemented")
+    }
+
+    override fun update(p0: Uri?, p1: ContentValues?, p2: String?, p3: Array<out String>?): Int {
+        throw UnsupportedOperationException("not implemented")
+    }
+
+    override fun delete(p0: Uri?, p1: String?, p2: Array<out String>?): Int {
+        throw UnsupportedOperationException("not implemented")
+    }
+}

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Tachiyomi</string>
-
     <string name="name">Име</string>
 
     <!-- Activities and fragments labels (toolbar title) -->

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Tachiyomi</string>
-
     <string name="name">Nombre</string>
 
     <!-- Activities and fragments labels (toolbar title) -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Tachiyomi</string>
-
     <string name="name">Nom</string>
 
     <!-- Activities and fragments labels (toolbar title) -->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Tachiyomi</string>
-
     <string name="name">Nome</string>
 
     <!-- Activities and fragments labels (toolbar title) -->

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Tachiyomi</string>
-
     <string name="name">Nome</string>
 
     <!-- Activities and fragments labels (toolbar title) -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Tachiyomi</string>
     <string name="action_add">Добавить</string>
     <string name="action_add_category">Добавить категорию</string>
     <string name="action_add_to_home_screen">Добавить на домашний экран</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Tachiyomi</string>
+    <string name="app_name" translatable="false">Tachiyomi</string>
 
     <string name="name">Name</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,6 +224,7 @@
     <string name="select_source">Select a source</string>
     <string name="no_valid_sources">Please enable at least one valid source</string>
     <string name="no_more_results">No more results</string>
+    <string name="local_source">Local mangas</string>
 
     <!-- Manga activity -->
     <string name="manga_not_in_db">This manga was removed from the database!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,7 +224,7 @@
     <string name="select_source">Select a source</string>
     <string name="no_valid_sources">Please enable at least one valid source</string>
     <string name="no_more_results">No more results</string>
-    <string name="local_source">Local mangas</string>
+    <string name="local_source">Local manga</string>
 
     <!-- Manga activity -->
     <string name="manga_not_in_db">This manga was removed from the database!</string>


### PR DESCRIPTION
This source allows to read locally stored mangas in zip/cbz/folder format.
The zip/cbz/folder files of each manga must be stored in a subdirectory of `/sdcard/Tachiyomi/mangas/`. As example:
```
/sdcard/Tachiyomi/mangas/MANGA_TITLE_1/chapter_1.zip
/sdcard/Tachiyomi/mangas/MANGA_TITLE_1/chapter_2.zip
/sdcard/Tachiyomi/mangas/MANGA_TITLE_2/chapter_1.cbz
/sdcard/Tachiyomi/mangas/MANGA_TITLE_2/cover.jpg
/sdcard/Tachiyomi/mangas/MANGA_TITLE_3/chapter_1_folder
/sdcard/Tachiyomi/mangas/MANGA_TITLE_3/chapter_2_folder
...
```
If a `cover.jpg` file is present it is used as cover for the manga.

The source extracts the zip/cbz files to the chache directory . A better option would be to directly read the image files from the .zip by using `java.net.URL("jar:file://sdcard/Tachiyomi/mangas/m1/c1.zip!/i1.jpg").openStream()`, but it requires changes in the `subsampling-scale-image-view` and `RapidDecoder` libraries.