### PR TITLE
Allow multiple sources in each extension source apk

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceFactory.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceFactory.kt
@@ -1,0 +1,12 @@
+package eu.kanade.tachiyomi.source
+
+/**
+ * A factory for creating sources at runtime.
+ */
+interface SourceFactory {
+    /**
+     * Create a new copy of the sources
+     * @return The created sources
+     */
+    fun createSources(): List<Source>
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
@@ -126,8 +126,13 @@ open class SourceManager(private val context: Context) {
         }
 
         val classLoader = PathClassLoader(ext.appInfo.sourceDir, null, context.classLoader)
-        return ext.sourceClasses.map {
-            Class.forName(it, false, classLoader).newInstance() as Source
+        return ext.sourceClasses.flatMap {
+            val obj = Class.forName(it, false, classLoader).newInstance()
+            when(obj) {
+                is Source -> listOf(obj)
+                is SourceFactory -> obj.createSources()
+                else -> throw Exception("Unknown source class type!")
+            }
         }
     }
 
@@ -140,7 +145,7 @@ open class SourceManager(private val context: Context) {
         const val EXTENSION_FEATURE = "tachiyomi.extension"
         const val METADATA_SOURCE_CLASS = "tachiyomi.extension.class"
         const val LIB_VERSION_MIN = 1
-        const val LIB_VERSION_MAX = 1
+        const val LIB_VERSION_MAX = 2
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
@@ -74,7 +74,7 @@ open class SourceManager(private val context: Context) {
                     val map = file.inputStream().use { yaml.loadAs(it, Map::class.java) }
                     sources.add(YamlHttpSource(map))
                 } catch (e: Exception) {
-                    Timber.e("Error loading source from file. Bad format?")
+                    Timber.e("Error loading source from file. Bad format?", e)
                 }
             }
         }
@@ -95,25 +95,29 @@ open class SourceManager(private val context: Context) {
             val extName = pkgManager.getApplicationLabel(appInfo).toString()
                     .substringAfter("Tachiyomi: ")
             val version = pkgInfo.versionName
-            var sourceClass = appInfo.metaData.getString(METADATA_SOURCE_CLASS)
-            if (sourceClass.startsWith(".")) {
-                sourceClass = pkgInfo.packageName + sourceClass
-            }
+            val sourceClasses = appInfo.metaData.getString(METADATA_SOURCE_CLASS)
+                    .split(";")
+                    .map {
+                        val sourceClass = it.trim()
+                        if(sourceClass.startsWith("."))
+                            pkgInfo.packageName + sourceClass
+                        else
+                            sourceClass
+                    }
 
-            val extension = Extension(extName, appInfo, version, sourceClass)
+            val extension = Extension(extName, appInfo, version, sourceClasses)
             try {
-                val instance = loadExtension(extension)
-                sources.add(instance)
+                sources += loadExtension(extension)
             } catch (e: Exception) {
-                Timber.e("Extension load error: $extName. Reason: ${e.message}")
+                Timber.e("Extension load error: $extName.", e)
             } catch (e: LinkageError) {
-                Timber.e("Extension load error: $extName. Reason: ${e.message}")
+                Timber.e("Extension load error: $extName.", e)
             }
         }
         return sources
     }
 
-    private fun loadExtension(ext: Extension): Source {
+    private fun loadExtension(ext: Extension): List<Source> {
         // Validate lib version
         val majorLibVersion = ext.version.substringBefore('.').toInt()
         if (majorLibVersion < LIB_VERSION_MIN || majorLibVersion > LIB_VERSION_MAX) {
@@ -122,13 +126,15 @@ open class SourceManager(private val context: Context) {
         }
 
         val classLoader = PathClassLoader(ext.appInfo.sourceDir, null, context.classLoader)
-        return Class.forName(ext.sourceClass, false, classLoader).newInstance() as Source
+        return ext.sourceClasses.map {
+            Class.forName(it, false, classLoader).newInstance() as Source
+        }
     }
 
     class Extension(val name: String,
                     val appInfo: ApplicationInfo,
                     val version: String,
-                    val sourceClass: String)
+                    val sourceClasses: List<String>)
 
     private companion object {
         const val EXTENSION_FEATURE = "tachiyomi.extension"

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceManager.kt
@@ -145,7 +145,7 @@ open class SourceManager(private val context: Context) {
         const val EXTENSION_FEATURE = "tachiyomi.extension"
         const val METADATA_SOURCE_CLASS = "tachiyomi.extension.class"
         const val LIB_VERSION_MIN = 1
-        const val LIB_VERSION_MAX = 2
+        const val LIB_VERSION_MAX = 1
     }
 
 }


### PR DESCRIPTION
Add the ability to specify multiple source classes in a single extension apk.

Source classes should be separated by `;`. Spaces are permitted between source classes. Old sources are backwards compatible.

SourceFactories can also be defined after this patch. SourceFactories allow extensions to specify a class that can create multiple sources when loaded. (Requires PR: https://github.com/inorichi/tachiyomi-extensions-lib/pull/1)

**Not sure if we should bump the version number of the source library? I considered this because new extension sources that contain multiple source classes will not be compatible with old versions of Tachiyomi.**

Also did a bit of code cleanup and increased verbosity of error messages