### PR TITLE
Fix issues with Batoto

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Batoto.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Batoto.kt
@@ -28,7 +28,7 @@ class Batoto : ParsedHttpSource(), LoginSource {
 
     override val name = "Batoto"
 
-    override val baseUrl = "http://bato.to"
+    override val baseUrl = "https://bato.to"
 
     override val lang = "en"
 
@@ -52,7 +52,7 @@ class Batoto : ParsedHttpSource(), LoginSource {
             .add("Cookie", "lang_option=English")
 
     private val pageHeaders = super.headersBuilder()
-            .add("Referer", "http://bato.to/reader")
+            .add("Referer", "$baseUrl/reader")
             .build()
 
     override fun popularMangaRequest(page: Int): Request {
@@ -69,7 +69,7 @@ class Batoto : ParsedHttpSource(), LoginSource {
 
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
-        element.select("a[href^=http://bato.to]").first().let {
+        element.select("a[href^=$baseUrl]").first().let {
             manga.setUrlWithoutDomain(it.attr("href"))
             manga.title = it.text().trim()
         }
@@ -177,7 +177,7 @@ class Batoto : ParsedHttpSource(), LoginSource {
     override fun chapterListSelector() = "tr.row.lang_English.chapter_row"
 
     override fun chapterFromElement(element: Element): SChapter {
-        val urlElement = element.select("a[href^=http://bato.to/reader").first()
+        val urlElement = element.select("a[href^=$baseUrl/reader").first()
 
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain(urlElement.attr("href"))


### PR DESCRIPTION
Some links now use https rather than http, so parsing was affected. I don't know if this is a permanent change on Batoto's end, but it does fix the issue of not being able to load any manga from Batoto in Tachiyomi (built from master branch). Fixes #872.