### PR TITLE
Add Manga Fox Chapter titles if exist

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/ChapterImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/ChapterImpl.kt
@@ -31,9 +31,10 @@ class ChapterImpl : Chapter {
         if (other == null || javaClass != other.javaClass) return false
 
         val chapter = other as Chapter
-        // Forces updates on manga if scanlator changes. This will allow existing manga in library
-        // with scanlator to update.
-        return url == chapter.url && scanlator == chapter.scanlator
+        // Forces updates on manga if url, scanlator, or chapter name changes.
+        //this allows existing libraries to be updated with chapter name changes/scanlator changes
+        //from the source site
+        return url == chapter.url && scanlator == chapter.scanlator  && name == chapter.name
 
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/ChapterImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/ChapterImpl.kt
@@ -31,10 +31,8 @@ class ChapterImpl : Chapter {
         if (other == null || javaClass != other.javaClass) return false
 
         val chapter = other as Chapter
-        // Forces updates on manga if url, scanlator, or chapter name changes.
-        //this allows existing libraries to be updated with chapter name changes/scanlator changes
-        //from the source site
-        return url == chapter.url && scanlator == chapter.scanlator  && name == chapter.name
+
+        return url == chapter.url
 
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
@@ -114,6 +114,7 @@ class Mangafox : ParsedHttpSource() {
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain(urlElement.attr("href"))
         chapter.name = urlElement.text()
+        chapter.name = element.select("span.title.nowrap").first()?.text()?.let {urlElement.text() + ": " + it}?: urlElement.text()
         chapter.date_upload = element.select("span.date").first()?.text()?.let { parseChapterDate(it) } ?: 0
         return chapter
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
@@ -114,7 +114,7 @@ class Mangafox : ParsedHttpSource() {
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain(urlElement.attr("href"))
         chapter.name = urlElement.text()
-        chapter.name = element.select("span.title.nowrap").first()?.text()?.let {urlElement.text() + ": " + it}?: urlElement.text()
+        chapter.name = element.select("span.title.nowrap").first()?.text()?.let {urlElement.text() + "- " + it}?: urlElement.text()
         chapter.date_upload = element.select("span.date").first()?.text()?.let { parseChapterDate(it) } ?: 0
         return chapter
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
@@ -113,7 +113,6 @@ class Mangafox : ParsedHttpSource() {
 
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain(urlElement.attr("href"))
-        chapter.name = urlElement.text()
         chapter.name = element.select("span.title.nowrap").first()?.text()?.let {urlElement.text() + " - " + it}?: urlElement.text()
         chapter.date_upload = element.select("span.date").first()?.text()?.let { parseChapterDate(it) } ?: 0
         return chapter

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
@@ -114,7 +114,7 @@ class Mangafox : ParsedHttpSource() {
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain(urlElement.attr("href"))
         chapter.name = urlElement.text()
-        chapter.name = element.select("span.title.nowrap").first()?.text()?.let {urlElement.text() + "- " + it}?: urlElement.text()
+        chapter.name = element.select("span.title.nowrap").first()?.text()?.let {urlElement.text() + " - " + it}?: urlElement.text()
         chapter.date_upload = element.select("span.date").first()?.text()?.let { parseChapterDate(it) } ?: 0
         return chapter
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterSourceSync.kt
@@ -38,7 +38,7 @@ fun syncChaptersWithSource(db: DatabaseHelper,
     }
 
     // Chapters from the source not in db.
-    val toAdd = sourceChapters.filterNot { it in dbChapters }
+    val toAdd = sourceChapters.filterNot { dbChapters.find {chapter -> chapter.url == it.url && chapter.name == it.name && chapter.scanlator == it.scanlator}?.let { true }?:false}
 
     // Recognize number for new chapters.
     toAdd.forEach {
@@ -49,7 +49,7 @@ fun syncChaptersWithSource(db: DatabaseHelper,
     }
 
     // Chapters from the db not in the source.
-    val toDelete = dbChapters.filterNot { it in sourceChapters }
+    val toDelete = dbChapters.filterNot { sourceChapters.find {chapter -> chapter.url == it.url && chapter.name == it.name && chapter.scanlator == it.scanlator}?.let { true }?:false}
 
     // Return if there's nothing to add or delete, avoiding unnecessary db transactions.
     if (toAdd.isEmpty() && toDelete.isEmpty()) {
@@ -94,4 +94,5 @@ fun syncChaptersWithSource(db: DatabaseHelper,
         db.fixChaptersSourceOrder(sourceChapters).executeAsBlocking()
     }
     return Pair(toAdd.subtract(readded).toList(), toDelete.subtract(readded).toList())
+
 }


### PR DESCRIPTION
Addresses
#926 

null safe check to see if chapter title exists for a manga if so appends it to the chapter name.
Also adjusted chapter impl so that if a name changes from the source for an existing manga in library the name change will reflect in the existing chapters.
