### PR TITLE
added licensed element check for MangaFox

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
@@ -89,13 +89,20 @@ class Mangafox : ParsedHttpSource() {
         val infoElement = document.select("div#title").first()
         val rowElement = infoElement.select("table > tbody > tr:eq(1)").first()
         val sideInfoElement = document.select("#series_info").first()
+        val licensedElement = document.select("div.warning").first()
 
         val manga = SManga.create()
         manga.author = rowElement.select("td:eq(1)").first()?.text()
         manga.artist = rowElement.select("td:eq(2)").first()?.text()
         manga.genre = rowElement.select("td:eq(3)").first()?.text()
         manga.description = infoElement.select("p.summary").first()?.text()
-        manga.status = sideInfoElement.select(".data").first()?.text().orEmpty().let { parseStatus(it) }
+        val isLicensed = licensedElement?.text()?.contains("licensed")
+        if (isLicensed == true) {
+            manga.status = SManga.LICENSED
+        } else {
+            manga.status = sideInfoElement.select(".data").first()?.text().orEmpty().let { parseStatus(it) }
+        }
+
         manga.thumbnail_url = sideInfoElement.select("div.cover > img").first()?.attr("src")
         return manga
     }


### PR DESCRIPTION
@inorichi fixed issue you were mentioning about warning div.

Verifies the warning div contains licensed before assigning it as licensed.

![image](https://user-images.githubusercontent.com/2092019/30279341-e334b618-96da-11e7-82dc-a75fe04b0dcf.png)
vs adult non licensed
![image](https://user-images.githubusercontent.com/2092019/30279357-ee871dd0-96da-11e7-9da8-b92c89d312c5.png)
