### PR TITLE
Download Badge Cache

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -40,6 +40,7 @@ open class App : Application() {
         LocaleHelper.updateConfiguration(this, resources.configuration)
     }
 
+
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(base)
         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -40,7 +40,6 @@ open class App : Application() {
         LocaleHelper.updateConfiguration(this, resources.configuration)
     }
 
-
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(base)
         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenHelper.kt
@@ -17,7 +17,7 @@ class DbOpenHelper(context: Context)
         /**
          * Version of the database.
          */
-        const val DATABASE_VERSION = 5
+        const val DATABASE_VERSION = 6
     }
 
     override fun onCreate(db: SQLiteDatabase) = with(db) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenHelper.kt
@@ -54,6 +54,9 @@ class DbOpenHelper(context: Context)
         if (oldVersion < 5) {
             db.execSQL(ChapterTable.addScanlator)
         }
+        if (oldVersion <6){
+            db.execSQL(MangaTable.addDownloadCount)
+        }
     }
 
     override fun onConfigure(db: SQLiteDatabase) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenHelper.kt
@@ -6,7 +6,7 @@ import android.database.sqlite.SQLiteOpenHelper
 import eu.kanade.tachiyomi.data.database.tables.*
 
 class DbOpenHelper(context: Context)
-: SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
+    : SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
 
     companion object {
         /**
@@ -54,7 +54,7 @@ class DbOpenHelper(context: Context)
         if (oldVersion < 5) {
             db.execSQL(ChapterTable.addScanlator)
         }
-        if (oldVersion <6){
+        if (oldVersion < 6) {
             db.execSQL(MangaTable.addDownloadCount)
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/mappers/MangaTypeMapping.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/mappers/MangaTypeMapping.kt
@@ -15,6 +15,7 @@ import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_ARTIST
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_AUTHOR
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_CHAPTER_FLAGS
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_DESCRIPTION
+import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_DOWNLOAD_COUNT
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_FAVORITE
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_GENRE
 import eu.kanade.tachiyomi.data.database.tables.MangaTable.COL_ID
@@ -62,6 +63,7 @@ class MangaPutResolver : DefaultPutResolver<Manga>() {
         put(COL_INITIALIZED, obj.initialized)
         put(COL_VIEWER, obj.viewer)
         put(COL_CHAPTER_FLAGS, obj.chapter_flags)
+        put(COL_DOWNLOAD_COUNT, obj.download_count)
     }
 }
 
@@ -82,6 +84,7 @@ interface BaseMangaGetResolver {
         initialized = cursor.getInt(cursor.getColumnIndex(COL_INITIALIZED)) == 1
         viewer = cursor.getInt(cursor.getColumnIndex(COL_VIEWER))
         chapter_flags = cursor.getInt(cursor.getColumnIndex(COL_CHAPTER_FLAGS))
+        download_count = cursor.getInt(cursor.getColumnIndex(COL_DOWNLOAD_COUNT))
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
@@ -16,6 +16,8 @@ interface Manga : SManga {
 
     var chapter_flags: Int
 
+    var download_count: Int
+
     fun setChapterOrder(order: Int) {
         setFlags(order, SORT_MASK)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaImpl.kt
@@ -32,6 +32,8 @@ open class MangaImpl : Manga {
 
     override var chapter_flags: Int = 0
 
+    override var download_count: Int = 0
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || javaClass != other.javaClass) return false

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.data.database.DbProvider
 import eu.kanade.tachiyomi.data.database.models.LibraryManga
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.resolvers.LibraryMangaGetResolver
+import eu.kanade.tachiyomi.data.database.resolvers.MangaDownloadCountPutResolver
 import eu.kanade.tachiyomi.data.database.resolvers.MangaFlagsPutResolver
 import eu.kanade.tachiyomi.data.database.resolvers.MangaLastUpdatedPutResolver
 import eu.kanade.tachiyomi.data.database.tables.CategoryTable
@@ -72,6 +73,11 @@ interface MangaQueries : DbProvider {
     fun updateLastUpdated(manga: Manga) = db.put()
             .`object`(manga)
             .withPutResolver(MangaLastUpdatedPutResolver())
+            .prepare()
+
+    fun updateDownloadCount(manga: Manga) = db.put()
+            .`object`(manga)
+            .withPutResolver(MangaDownloadCountPutResolver())
             .prepare()
 
     fun deleteManga(manga: Manga) = db.delete().`object`(manga).prepare()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/resolvers/MangaDownloadCountPutResolver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/resolvers/MangaDownloadCountPutResolver.kt
@@ -1,0 +1,38 @@
+package eu.kanade.tachiyomi.data.database.resolvers
+
+/**
+ * Created by Carlos on 11/26/2017.
+ */
+
+import android.content.ContentValues
+import com.pushtorefresh.storio.sqlite.StorIOSQLite
+import com.pushtorefresh.storio.sqlite.operations.put.PutResolver
+import com.pushtorefresh.storio.sqlite.operations.put.PutResult
+import com.pushtorefresh.storio.sqlite.queries.UpdateQuery
+import eu.kanade.tachiyomi.data.database.inTransactionReturn
+import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.database.tables.MangaTable
+import timber.log.Timber
+
+class MangaDownloadCountPutResolver : PutResolver<Manga>() {
+
+    override fun performPut(db: StorIOSQLite, manga: Manga) = db.inTransactionReturn {
+        val updateQuery = mapToUpdateQuery(manga)
+        val contentValues = mapToContentValues(manga)
+
+        val numberOfRowsUpdated = db.lowLevel().update(updateQuery, contentValues)
+        PutResult.newUpdateResult(numberOfRowsUpdated, updateQuery.table())
+    }
+
+    fun mapToUpdateQuery(manga: Manga) = UpdateQuery.builder()
+            .table(MangaTable.TABLE)
+            .where("${MangaTable.COL_ID} = ?")
+            .whereArgs(manga.id)
+            .build()
+
+    fun mapToContentValues(manga: Manga) = ContentValues(1).apply {
+        Timber.d("manga download count: %s", manga.download_count)
+        put(MangaTable.COL_DOWNLOAD_COUNT, manga.download_count)
+    }
+
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/MangaTable.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/MangaTable.kt
@@ -38,6 +38,8 @@ object MangaTable {
 
     const val COL_CATEGORY = "category"
 
+    const val COL_DOWNLOAD_COUNT = "download_count"
+
     val createTableQuery: String
         get() = """CREATE TABLE $TABLE(
             $COL_ID INTEGER NOT NULL PRIMARY KEY,
@@ -54,7 +56,8 @@ object MangaTable {
             $COL_LAST_UPDATE LONG,
             $COL_INITIALIZED BOOLEAN NOT NULL,
             $COL_VIEWER INTEGER NOT NULL,
-            $COL_CHAPTER_FLAGS INTEGER NOT NULL
+            $COL_CHAPTER_FLAGS INTEGER NOT NULL,
+            $COL_DOWNLOAD_COUNT INTEGER
             )"""
 
     val createUrlIndexQuery: String
@@ -62,4 +65,7 @@ object MangaTable {
 
     val createFavoriteIndexQuery: String
         get() = "CREATE INDEX ${TABLE}_${COL_FAVORITE}_index ON $TABLE($COL_FAVORITE)"
+
+    val addDownloadCount: String
+        get() = "ALTER TABLE $TABLE ADD COLUMN $COL_DOWNLOAD_COUNT INTEGER DEFAULT 0"
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -3,12 +3,15 @@ package eu.kanade.tachiyomi.data.download
 import android.content.Context
 import com.hippo.unifile.UniFile
 import com.jakewharton.rxrelay.BehaviorRelay
+import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.model.DownloadQueue
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.Page
 import rx.Observable
+import timber.log.Timber
+import uy.kohesive.injekt.injectLazy
 
 /**
  * This class is used to manage chapter downloads in the application. It must be instantiated once
@@ -28,6 +31,11 @@ class DownloadManager(context: Context) {
      * Downloader whose only task is to download chapters.
      */
     private val downloader = Downloader(context, provider)
+
+    /*
+        DB helper
+     */
+    private val db: DatabaseHelper by injectLazy()
 
     /**
      * Downloads queue, where the pending chapters are stored.
@@ -175,6 +183,11 @@ class DownloadManager(context: Context) {
      * @param chapter the chapter to delete.
      */
     fun deleteChapter(source: Source, manga: Manga, chapter: Chapter) {
+        Timber.d("delete chapter")
         provider.findChapterDir(source, manga, chapter)?.delete()
+        manga.download_count = manga.download_count -1
+        db.updateDownloadCount(manga).executeAsBlocking()
+
+
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -10,7 +10,6 @@ import eu.kanade.tachiyomi.data.download.model.DownloadQueue
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.Page
 import rx.Observable
-import timber.log.Timber
 import uy.kohesive.injekt.injectLazy
 
 /**
@@ -183,11 +182,8 @@ class DownloadManager(context: Context) {
      * @param chapter the chapter to delete.
      */
     fun deleteChapter(source: Source, manga: Manga, chapter: Chapter) {
-        Timber.d("delete chapter")
         provider.findChapterDir(source, manga, chapter)?.delete()
-        manga.download_count = manga.download_count -1
+        manga.download_count = manga.download_count - 1
         db.updateDownloadCount(manga).executeAsBlocking()
-
-
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -5,6 +5,7 @@ import android.webkit.MimeTypeMap
 import com.hippo.unifile.UniFile
 import com.jakewharton.rxrelay.BehaviorRelay
 import com.jakewharton.rxrelay.PublishRelay
+import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.model.Download
@@ -59,6 +60,11 @@ class Downloader(private val context: Context, private val provider: DownloadPro
      * Preferences.
      */
     private val preferences: PreferencesHelper by injectLazy()
+
+    /*
+        DB helper
+     */
+    private val db: DatabaseHelper by injectLazy()
 
     /**
      * Notifier for the downloader state and progress.
@@ -192,7 +198,8 @@ class Downloader(private val context: Context, private val provider: DownloadPro
                 .lift(DynamicConcurrentMergeOperator<Download, Download>({ downloadChapter(it) }, threadsSubject))
                 .onBackpressureBuffer()
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({ completeDownload(it)
+                .subscribe({
+                    completeDownload(it)
                 }, { error ->
                     DownloadService.stop(context)
                     Timber.e(error)
@@ -399,10 +406,10 @@ class Downloader(private val context: Context, private val provider: DownloadPro
     private fun getImageExtension(response: Response, file: UniFile): String {
         // Read content type if available.
         val mime = response.body()?.contentType()?.let { ct -> "${ct.type()}/${ct.subtype()}" }
-            // Else guess from the uri.
-            ?: context.contentResolver.getType(file.uri)
-            // Else read magic numbers.
-            ?: DiskUtil.findImageMime { file.openInputStream() }
+                // Else guess from the uri.
+                ?: context.contentResolver.getType(file.uri)
+                // Else read magic numbers.
+                ?: DiskUtil.findImageMime { file.openInputStream() }
 
         return MimeTypeMap.getSingleton().getExtensionFromMimeType(mime) ?: "jpg"
     }
@@ -427,6 +434,9 @@ class Downloader(private val context: Context, private val provider: DownloadPro
         // Only rename the directory if it's downloaded.
         if (download.status == Download.DOWNLOADED) {
             tmpDir.renameTo(dirname)
+                 //update download count
+                download.manga.download_count++
+                db.updateDownloadCount(download.manga).executeAsBlocking()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -434,9 +434,9 @@ class Downloader(private val context: Context, private val provider: DownloadPro
         // Only rename the directory if it's downloaded.
         if (download.status == Download.DOWNLOADED) {
             tmpDir.renameTo(dirname)
-                 //update download count
-                download.manga.download_count++
-                db.updateDownloadCount(download.manga).executeAsBlocking()
+            //update download count
+            download.manga.download_count++
+            db.updateDownloadCount(download.manga).executeAsBlocking()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -107,6 +107,8 @@ object PreferenceKeys {
 
     const val downloadBadge = "display_download_badge"
 
+    const val downloadBadgeUpdate = "update_download_badge"
+
     fun sourceUsername(sourceId: Long) = "pref_source_username_$sourceId"
 
     fun sourcePassword(sourceId: Long) = "pref_source_password_$sourceId"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -143,6 +143,8 @@ class PreferencesHelper(val context: Context) {
 
     fun downloadBadge() = rxPrefs.getBoolean(Keys.downloadBadge, false)
 
+    fun downloadBadgeUpdate() = rxPrefs.getLong(Keys.downloadBadgeUpdate, 0)
+
     fun filterDownloaded() = rxPrefs.getBoolean(Keys.filterDownloaded, false)
 
     fun filterUnread() = rxPrefs.getBoolean(Keys.filterUnread, false)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryView.kt
@@ -94,6 +94,8 @@ class LibraryCategoryView @JvmOverloads constructor(context: Context, attrs: Att
             if (!LibraryUpdateService.isRunning(context)) {
                 LibraryUpdateService.start(context, category)
                 context.toast(R.string.updating_category)
+                preferences.downloadBadgeUpdate().set(0)
+                controller.onDownloadBadgeChanged()
             }
             // It can be a very long operation, so we disable swipe refresh and show a toast.
             swipe_refresh.isRefreshing = false

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -231,7 +231,6 @@ class LibraryController(
     }
 
     fun onNextLibraryUpdate(categories: List<Category>, mangaMap: Map<Int, List<LibraryItem>>) {
-        Timber.d("onNextLibraryUpdate")
         val view = view ?: return
         val adapter = adapter ?: return
 
@@ -287,7 +286,7 @@ class LibraryController(
         activity?.invalidateOptionsMenu()
     }
 
-    fun onDownloadBadgeChanged(){
+    fun onDownloadBadgeChanged() {
         presenter.requestDownloadBadgesUpdate()
     }
 
@@ -371,7 +370,8 @@ class LibraryController(
                 activity?.let {
                     preferences.downloadBadgeUpdate().set(0)
                     onDownloadBadgeChanged()
-                    LibraryUpdateService.start(it) }
+                    LibraryUpdateService.start(it)
+                }
             }
             R.id.action_edit_categories -> {
                 router.pushController(RouterTransaction.with(CategoryController())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -231,6 +231,7 @@ class LibraryController(
     }
 
     fun onNextLibraryUpdate(categories: List<Category>, mangaMap: Map<Int, List<LibraryItem>>) {
+        Timber.d("onNextLibraryUpdate")
         val view = view ?: return
         val adapter = adapter ?: return
 
@@ -286,7 +287,7 @@ class LibraryController(
         activity?.invalidateOptionsMenu()
     }
 
-    private fun onDownloadBadgeChanged(){
+    fun onDownloadBadgeChanged(){
         presenter.requestDownloadBadgesUpdate()
     }
 
@@ -367,7 +368,10 @@ class LibraryController(
                 navView?.let { drawer?.openDrawer(Gravity.END) }
             }
             R.id.action_update_library -> {
-                activity?.let { LibraryUpdateService.start(it) }
+                activity?.let {
+                    preferences.downloadBadgeUpdate().set(0)
+                    onDownloadBadgeChanged()
+                    LibraryUpdateService.start(it) }
             }
             R.id.action_edit_categories -> {
                 router.pushController(RouterTransaction.with(CategoryController())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -168,9 +168,7 @@ class LibraryPresenter(
      * @param map the map of manga.
      */
     private fun setDownloadCount(map: LibraryMap) {
-        Timber.d("set download count")
         if (!preferences.downloadBadge().getOrDefault()) {
-            Timber.d("download badge disabled")
             // Unset download count if the preference is not enabled.
             for ((_, itemList) in map) {
                 for (item in itemList) {
@@ -179,9 +177,7 @@ class LibraryPresenter(
             }
             return
         }
-        Timber.d("download badge enabled")
         if (preferences.downloadBadgeUpdate().getOrDefault() != 0L) {
-            Timber.d("download badge update not 0")
             for ((_, itemList) in map) {
                 for (item in itemList) {
                     Timber.d(item.manga.title)
@@ -190,7 +186,6 @@ class LibraryPresenter(
                 }
             }
         } else {
-            Timber.d("download badge update  0")
             // Cached list of downloaded manga directories given a source id.
             val mangaDirsForSource = mutableMapOf<Long, Map<String?, UniFile>>()
 
@@ -223,7 +218,6 @@ class LibraryPresenter(
                     db.updateDownloadCount(item.manga).executeAsBlocking()
                 }
             }
-            Timber.d("set update time")
             preferences.downloadBadgeUpdate().set(System.currentTimeMillis());
         }
     }
@@ -345,7 +339,7 @@ class LibraryPresenter(
      */
     fun onOpenManga() {
         // Avoid further db updates for the library when it's not needed
-      //    librarySubscription?.let { remove(it) }
+        //    librarySubscription?.let { remove(it) }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -166,6 +166,7 @@ class MainActivity : BaseActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        preferences.downloadBadgeUpdate().set(0)
         nav_view?.setNavigationItemSelectedListener(null)
         toolbar?.setNavigationOnClickListener(null)
     }


### PR DESCRIPTION
#1078

Badges should be cached now and whether you delete or download a new chapter in app it will be displayed correctly.
If the chapter is deleted outside of the app it will require you to perform a update library call from the over flow menu, or a swipe to refresh library.

When app leaves memory download badges are recalculated.  Time constraint can be added in future if need be.  

Here is a dropbox for anyone wanting to verify this works for them.

https://www.dropbox.com/s/gpuecwgtfede2y2/tachiyomi-dev.apk?dl=0