### PR TITLE
FIx Batoto issues with logging in and loading lists/pages.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Batoto.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Batoto.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.selectText
 import okhttp3.FormBody
 import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -47,6 +48,8 @@ class Batoto : ParsedHttpSource(), LoginSource {
     }
 
     private val staffNotice = Pattern.compile("=+Batoto Staff Notice=+([^=]+)==+", Pattern.CASE_INSENSITIVE)
+
+    override val client: OkHttpClient = network.cloudflareClient
 
     override fun headersBuilder() = super.headersBuilder()
             .add("Cookie", "lang_option=English")


### PR DESCRIPTION
Fixes #1087. May also fix #1034, but I'm not sure.

Batoto added Cloudflare protection recently (I was sure they had already had Cloudflare, but apparently I was wrong), which interfered with logging in, loading the Popular/Latest lists, and downloading pages in chapters that were already in the library. Overriding HttpSource#client with network.cloudflareClient resolves all of these issues.