### PR TITLE
Change discord invite link in settings

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsAboutController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsAboutController.kt
@@ -71,7 +71,7 @@ class SettingsAboutController : SettingsController() {
         }
         preference {
             title = "Discord"
-            val url = "https://discord.gg/WrBkRk4"
+            val url = "https://discord.gg/2dDQBv2"
             summary = url
             onClick {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))


### PR DESCRIPTION
The old link still works and I'm not removing it, but this new one directs users to #rules instead of #general. Sadly it isn't possible to change it after a link has been created