### PR TITLE
[Mangafox] update mangafox URL for built-in source

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangafox.kt
@@ -17,7 +17,7 @@ class Mangafox : ParsedHttpSource() {
 
     override val name = "Mangafox"
 
-    override val baseUrl = "http://mangafox.me"
+    override val baseUrl = "http://mangafox.la"
 
     override val lang = "en"
 


### PR DESCRIPTION
Fixed in extensions as well - tachiyomi seems to prefer built-in source over external