### PR TITLE
Fix padding on RecyclerViews

### DIFF
--- a/app/src/main/res/layout/catalogue_global_search_controller.xml
+++ b/app/src/main/res/layout/catalogue_global_search_controller.xml
@@ -10,5 +10,6 @@ android:layout_height="wrap_content">
     android:layout_height="wrap_content"
     android:paddingBottom="4dp"
     android:paddingTop="4dp"
+    android:clipToPadding="false"
     tools:listitem="@layout/catalogue_global_search_controller_card" />
 </FrameLayout>

--- a/app/src/main/res/layout/catalogue_global_search_controller_card.xml
+++ b/app/src/main/res/layout/catalogue_global_search_controller_card.xml
@@ -78,6 +78,7 @@
             android:orientation="horizontal"
             android:paddingEnd="4dp"
             android:paddingStart="4dp"
+            android:clipToPadding="false"
             tools:listitem="@layout/catalogue_global_search_controller_card_item" />
     </android.support.v7.widget.CardView>
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/catalogue_recycler_autofit.xml
+++ b/app/src/main/res/layout/catalogue_recycler_autofit.xml
@@ -7,4 +7,5 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:columnWidth="140dp"
+    android:clipToPadding="false"
     tools:listitem="@layout/catalogue_grid_item" />

--- a/app/src/main/res/layout/library_grid_recycler.xml
+++ b/app/src/main/res/layout/library_grid_recycler.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<eu.kanade.tachiyomi.widget.AutofitRecyclerView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<eu.kanade.tachiyomi.widget.AutofitRecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/library_grid"
     style="@style/Theme.Widget.GridView.Catalogue"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:columnWidth="140dp"
+    android:clipToPadding="false"
     tools:listitem="@layout/catalogue_grid_item" />

--- a/app/src/main/res/layout/recently_read_controller.xml
+++ b/app/src/main/res/layout/recently_read_controller.xml
@@ -9,8 +9,9 @@
         android:id="@+id/recycler"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginBottom="4dp"
-        android:layout_marginTop="4dp"
+        android:paddingBottom="4dp"
+        android:paddingTop="4dp"
+        android:clipToPadding="false"
         tools:listitem="@layout/recently_read_item">
 
     </android.support.v7.widget.RecyclerView>


### PR DESCRIPTION
As you can see below, when scrolling, the RecyclerViews are clipping to the padding, bringing my OCD great distress.

Left = Before
Right = After
I have circled the points of interest in red.

![triggered](https://user-images.githubusercontent.com/9571936/34634221-dfe7b57a-f24f-11e7-8139-35fb70c6c3b0.png)

Notice that outrageous black line that cuts off the manga covers. It brings me great pain and I request to immediately abolish it through this PR!

*On a more serious note:* If that's actually the intended behavior, then feel free to close this PR.
