### PR TITLE
Fix lost library search

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -322,6 +322,11 @@ class LibraryController(
         val searchItem = menu.findItem(R.id.action_search)
         val searchView = searchItem.actionView as SearchView
 
+        if(!presenter.query.isEmpty()){
+            query = presenter.query
+            presenter.query = ""
+        }
+
         if (!query.isEmpty()) {
             searchItem.expandActionView()
             searchView.setQuery(query, true)
@@ -331,7 +336,7 @@ class LibraryController(
         // Mutate the filter icon because it needs to be tinted and the resource is shared.
         menu.findItem(R.id.action_filter).icon.mutate()
 
-        searchView.queryTextChanges().subscribeUntilDestroy {
+        searchView.queryTextChanges().subscribeUntilDetach {
             query = it.toString()
             searchRelay.call(query)
         }
@@ -413,6 +418,9 @@ class LibraryController(
     fun openManga(manga: Manga) {
         // Notify the presenter a manga is being opened.
         presenter.onOpenManga()
+
+        // Save current search query
+        presenter.query = query
 
         router.pushController(MangaController(manga).withFadeTransaction())
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -71,6 +71,11 @@ class LibraryController(
     private var query = ""
 
     /**
+     * We save the library search query when one manga is open.
+     */
+    private var backupQuery = ""
+
+    /**
      * Currently selected mangas.
      */
     val selectedMangas = mutableListOf<Manga>()
@@ -322,9 +327,9 @@ class LibraryController(
         val searchItem = menu.findItem(R.id.action_search)
         val searchView = searchItem.actionView as SearchView
 
-        if(!presenter.query.isEmpty()){
-            query = presenter.query
-            presenter.query = ""
+        if(!backupQuery.isEmpty()){
+            query = backupQuery
+            backupQuery = ""
         }
 
         if (!query.isEmpty()) {
@@ -420,7 +425,7 @@ class LibraryController(
         presenter.onOpenManga()
 
         // Save current search query
-        presenter.query = query
+        backupQuery = query
 
         router.pushController(MangaController(manga).withFadeTransaction())
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -57,6 +57,11 @@ class LibraryPresenter(
         private set
 
     /**
+     * Query from the view.
+     */
+    var query = ""
+
+    /**
      * Relay used to apply the UI filters to the last emission of the library.
      */
     private val filterTriggerRelay = BehaviorRelay.create(Unit)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -57,11 +57,6 @@ class LibraryPresenter(
         private set
 
     /**
-     * Query from the view.
-     */
-    var query = ""
-
-    /**
      * Relay used to apply the UI filters to the last emission of the library.
      */
     private val filterTriggerRelay = BehaviorRelay.create(Unit)


### PR DESCRIPTION
Adresses https://github.com/inorichi/tachiyomi/issues/1122

Saves the current search on the presenter when a manga is opened, return the saved search when back to the library view.