### PR TITLE
Handle ActivityNotFoundException

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBackupController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBackupController.kt
@@ -117,19 +117,25 @@ class SettingsBackupController : SettingsController() {
 
                 onClick {
                     val currentDir = preferences.backupsDirectory().getOrDefault()
+                    val customPicker = Intent(activity, CustomLayoutPickerActivity::class.java)
+                            .putExtra(FilePickerActivity.EXTRA_ALLOW_MULTIPLE, false)
+                            .putExtra(FilePickerActivity.EXTRA_ALLOW_CREATE_DIR, true)
+                            .putExtra(FilePickerActivity.EXTRA_MODE, FilePickerActivity.MODE_DIR)
+                            .putExtra(FilePickerActivity.EXTRA_START_PATH, currentDir)
 
                     val intent = if (Build.VERSION.SDK_INT < 21) {
                         // Custom dir selected, open directory selector
-                        val i = Intent(activity, CustomLayoutPickerActivity::class.java)
-                        i.putExtra(FilePickerActivity.EXTRA_ALLOW_MULTIPLE, false)
-                        i.putExtra(FilePickerActivity.EXTRA_ALLOW_CREATE_DIR, true)
-                        i.putExtra(FilePickerActivity.EXTRA_MODE, FilePickerActivity.MODE_DIR)
-                        i.putExtra(FilePickerActivity.EXTRA_START_PATH, currentDir)
-
+                        customPicker
                     } else {
                         Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
                     }
-                    startActivityForResult(intent, CODE_BACKUP_DIR)
+                    //Fall back to custom picker on error
+                    try{
+                        startActivityForResult(intent, CODE_BACKUP_DIR)
+                    } catch (e: ActivityNotFoundException){
+                        startActivityForResult(customPicker, CODE_BACKUP_DIR)
+                    }
+
                 }
 
                 preferences.backupsDirectory().asObservable()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBackupController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBackupController.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.ui.setting
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.app.Activity
 import android.app.Dialog
+import android.content.ActivityNotFoundException
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBackupController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBackupController.kt
@@ -125,7 +125,9 @@ class SettingsBackupController : SettingsController() {
                         startActivityForResult(intent, CODE_BACKUP_DIR)
                     } catch (e: ActivityNotFoundException){
                         //Fall back to custom picker on error
-                        startActivityForResult(preferences.context.getFilePicker(currentDir), CODE_BACKUP_DIR)
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+                            startActivityForResult(preferences.context.getFilePicker(currentDir), CODE_BACKUP_DIR)
+                        }
                     }
 
                 }
@@ -222,7 +224,9 @@ class SettingsBackupController : SettingsController() {
             startActivityForResult(intent, CODE_BACKUP_CREATE)
         } catch (e: ActivityNotFoundException) {
             // Handle errors where the android ROM doesn't support the built in picker
-            startActivityForResult(preferences.context.getFilePicker(currentDir), CODE_BACKUP_CREATE)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+                startActivityForResult(preferences.context.getFilePicker(currentDir), CODE_BACKUP_CREATE)
+            }
         }
 
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -160,7 +160,9 @@ class SettingsDownloadController : SettingsController() {
             try {
                 startActivityForResult(intent, DOWNLOAD_DIR_L)
             } catch (e: ActivityNotFoundException) {
-                startActivityForResult(preferences.context.getFilePicker(currentDir), DOWNLOAD_DIR_L)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    startActivityForResult(preferences.context.getFilePicker(currentDir), DOWNLOAD_DIR_L)
+                }
             }
 
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.preference.getOrDefault
 import eu.kanade.tachiyomi.ui.base.controller.DialogController
 import eu.kanade.tachiyomi.util.DiskUtil
+import eu.kanade.tachiyomi.util.getFilePicker
 import eu.kanade.tachiyomi.widget.CustomLayoutPickerActivity
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -151,20 +152,15 @@ class SettingsDownloadController : SettingsController() {
     }
 
     fun customDirectorySelected(currentDir: String) {
-        val customPicker = Intent(activity, CustomLayoutPickerActivity::class.java)
-                .putExtra(FilePickerActivity.EXTRA_ALLOW_MULTIPLE, false)
-                .putExtra(FilePickerActivity.EXTRA_ALLOW_CREATE_DIR, true)
-                .putExtra(FilePickerActivity.EXTRA_MODE, FilePickerActivity.MODE_DIR)
-                .putExtra(FilePickerActivity.EXTRA_START_PATH, currentDir)
 
-        if (Build.VERSION.SDK_INT < 21) {
-            startActivityForResult(customPicker, DOWNLOAD_DIR_PRE_L)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            startActivityForResult(preferences.context.getFilePicker(currentDir), DOWNLOAD_DIR_PRE_L)
         } else {
-            val i = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
             try {
-                startActivityForResult(i, DOWNLOAD_DIR_L)
+                startActivityForResult(intent, DOWNLOAD_DIR_L)
             } catch (e: ActivityNotFoundException) {
-                startActivityForResult(customPicker, DOWNLOAD_DIR_L)
+                startActivityForResult(preferences.context.getFilePicker(currentDir), DOWNLOAD_DIR_L)
             }
 
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.ui.setting
 
 import android.app.Activity
 import android.app.Dialog
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -150,17 +151,22 @@ class SettingsDownloadController : SettingsController() {
     }
 
     fun customDirectorySelected(currentDir: String) {
-        if (Build.VERSION.SDK_INT < 21) {
-            val i = Intent(activity, CustomLayoutPickerActivity::class.java)
-            i.putExtra(FilePickerActivity.EXTRA_ALLOW_MULTIPLE, false)
-            i.putExtra(FilePickerActivity.EXTRA_ALLOW_CREATE_DIR, true)
-            i.putExtra(FilePickerActivity.EXTRA_MODE, FilePickerActivity.MODE_DIR)
-            i.putExtra(FilePickerActivity.EXTRA_START_PATH, currentDir)
+        val customPicker = Intent(activity, CustomLayoutPickerActivity::class.java)
+                .putExtra(FilePickerActivity.EXTRA_ALLOW_MULTIPLE, false)
+                .putExtra(FilePickerActivity.EXTRA_ALLOW_CREATE_DIR, true)
+                .putExtra(FilePickerActivity.EXTRA_MODE, FilePickerActivity.MODE_DIR)
+                .putExtra(FilePickerActivity.EXTRA_START_PATH, currentDir)
 
-            startActivityForResult(i, DOWNLOAD_DIR_PRE_L)
+        if (Build.VERSION.SDK_INT < 21) {
+            startActivityForResult(customPicker, DOWNLOAD_DIR_PRE_L)
         } else {
             val i = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
-            startActivityForResult(i, DOWNLOAD_DIR_L)
+            try {
+                startActivityForResult(i, DOWNLOAD_DIR_L)
+            } catch (e: ActivityNotFoundException) {
+                startActivityForResult(customPicker, DOWNLOAD_DIR_L)
+            }
+
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ContextExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ContextExtensions.kt
@@ -16,6 +16,8 @@ import android.support.v4.app.NotificationCompat
 import android.support.v4.content.ContextCompat
 import android.support.v4.content.LocalBroadcastManager
 import android.widget.Toast
+import com.nononsenseapps.filepicker.FilePickerActivity
+import eu.kanade.tachiyomi.widget.CustomLayoutPickerActivity
 
 /**
  * Display a toast in this context.
@@ -48,6 +50,19 @@ inline fun Context.notification(channelId: String, func: NotificationCompat.Buil
     val builder = NotificationCompat.Builder(this, channelId)
     builder.func()
     return builder.build()
+}
+
+/**
+ * Helper method to construct an Intent to use a custom file picker.
+ * @param currentDir the path the file picker will open with.
+ * @return an Intent to start the file picker activity.
+ */
+fun Context.getFilePicker(currentDir: String): Intent {
+    return Intent(this, CustomLayoutPickerActivity::class.java)
+            .putExtra(FilePickerActivity.EXTRA_ALLOW_MULTIPLE, false)
+            .putExtra(FilePickerActivity.EXTRA_ALLOW_CREATE_DIR, true)
+            .putExtra(FilePickerActivity.EXTRA_MODE, FilePickerActivity.MODE_DIR)
+            .putExtra(FilePickerActivity.EXTRA_START_PATH, currentDir)
 }
 
 /**


### PR DESCRIPTION
When using `Intent.ACTION_CREATE_DOCUMENT` on SDK >= Lollipop there is no
guarantee that the ROM supports the built in file picker such as MIUI

A discord user had this issue which caused Tachiyomi to crash when trying to start a backup
![activitynotfoundexception](https://user-images.githubusercontent.com/2048861/34748431-78cdcf3c-f56a-11e7-9fff-74b3c594af06.png)

