### PR TITLE
Added select all above and below functions

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
@@ -334,6 +334,8 @@ class ChaptersController : NucleusController<ChaptersPresenter>(),
             R.id.action_mark_as_read -> markAsRead(chapters)
             R.id.action_mark_as_unread -> markAsUnread(chapters)
             R.id.action_mark_previous_as_read -> markPreviousAsRead(chapter)
+            R.id.action_select_all_above -> selectAbove(position)
+            R.id.action_select_all_below -> selectBelow(position)
         }
     }
 
@@ -343,6 +345,41 @@ class ChaptersController : NucleusController<ChaptersPresenter>(),
         val adapter = adapter ?: return
         adapter.selectAll()
         selectedItems.addAll(adapter.items)
+        actionMode?.invalidate()
+    }
+
+    fun selectAbove(position: Int){
+        createActionModeIfNeeded()
+        val adapter = adapter ?: return
+        var x = position
+        while (x >= 0){
+            var item = adapter.getItem(x)
+            if(!adapter.isSelected(x)){
+                adapter.toggleSelection(x)
+            }
+            if (adapter.isSelected(x) && item != null) {
+                selectedItems.add(item)
+            }
+            x--
+        }
+        adapter.notifyDataSetChanged()
+        actionMode?.invalidate()
+    }
+    fun selectBelow(position: Int){
+        createActionModeIfNeeded()
+        val adapter = adapter ?: return
+        var x = position
+        while (x <= adapter.itemCount){
+            var item = adapter.getItem(x)
+            if(!adapter.isSelected(x)){
+                adapter.toggleSelection(x)
+            }
+            if (adapter.isSelected(x) && item != null) {
+                selectedItems.add(item)
+            }
+            x++
+        }
+        adapter.notifyDataSetChanged()
         actionMode?.invalidate()
     }
 

--- a/app/src/main/res/menu/chapter_single.xml
+++ b/app/src/main/res/menu/chapter_single.xml
@@ -28,4 +28,10 @@
     <item android:id="@+id/action_mark_previous_as_read"
           android:title="@string/action_mark_previous_as_read"/>
 
+    <item android:id="@+id/action_select_all_above"
+        android:title="@string/action_select_all_above" />
+
+    <item android:id="@+id/action_select_all_below"
+        android:title="@string/action_select_all_below"/>
+
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="action_search">Search</string>
     <string name="action_global_search">Global search</string>
     <string name="action_select_all">Select all</string>
+    <string name="action_select_all_above">Select all above</string>
+    <string name="action_select_all_below">Select all below</string>
     <string name="action_mark_as_read">Mark as read</string>
     <string name="action_mark_as_unread">Mark as unread</string>
     <string name="action_mark_previous_as_read">Mark previous as read</string>


### PR DESCRIPTION
There are times when I really want to be able to select a number of chapters that I've already read, but I can't select all since I haven't finished the manga yet. With these 2 new options, you'll be able to easily select all the chapters above or below a given chapter. I think this would be really useful to others to save time (in case they want to select 200+ out of 300 chapters for example).

![screenshot_20180116-233950](https://user-images.githubusercontent.com/6703359/35031600-7f36325c-fb18-11e7-9379-14989c85313a.png)
![screenshot_20180116-233956](https://user-images.githubusercontent.com/6703359/35031603-833bdeba-fb18-11e7-8751-1f9f393a8178.png)
