### PR TITLE
Fix chapter recognition regex and detail number

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -251,7 +251,7 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
         if (count > 0f) {
             manga_chapters?.text = DecimalFormat("#.#").format(count)
         } else {
-            manga_chapters?.text = resources?.getString(R.string.unknown)
+            manga_chapters?.text = resources!!.getString(R.string.unknown)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -251,7 +251,7 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
         if (count > 0f) {
             manga_chapters?.text = DecimalFormat("#.#").format(count)
         } else {
-            manga_chapters?.text = resources!!.getString(R.string.unknown)
+            manga_chapters?.text = resources?.getString(R.string.unknown)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -7,7 +7,6 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Build
@@ -91,7 +90,7 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
         // Set SwipeRefresh to refresh manga data.
         swipe_refresh.refreshes().subscribeUntilDestroy { fetchMangaFromSource() }
 
-        manga_full_title.longClicks().subscribeUntilDestroy{
+        manga_full_title.longClicks().subscribeUntilDestroy {
             copyToClipboard(view.context.getString(R.string.title), manga_full_title.text.toString())
         }
 
@@ -191,14 +190,14 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
         }
 
         // If manga source is known update source TextView.
-        manga_source.text = if(source == null) {
+        manga_source.text = if (source == null) {
             view.context.getString(R.string.unknown)
         } else {
             source.toString()
         }
 
         // Update genres list
-        if(manga.genre.isNullOrBlank().not()){
+        if (manga.genre.isNullOrBlank().not()) {
             manga_genres_tags.setTags(manga.genre?.split(", "))
         }
 
@@ -249,10 +248,12 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
      * @param count number of chapters.
      */
     fun setChapterCount(count: Float) {
-        manga_chapters?.text = DecimalFormat("#.#").format(count)
+        if (count > 0f) {
+            manga_chapters?.text = DecimalFormat("#.#").format(count)
+        }
     }
 
-    fun setLastUpdateDate(date: Date){
+    fun setLastUpdateDate(date: Date) {
         manga_last_update?.text = DateFormat.getDateInstance(DateFormat.SHORT).format(date)
     }
 
@@ -381,7 +382,7 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
                 }
             }
             activity?.toast(activity?.getString(R.string.manga_added_library))
-        }else{
+        } else {
             activity?.toast(activity?.getString(R.string.manga_removed_library))
         }
     }
@@ -465,8 +466,8 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
      * @param label Label to show to the user describing the content
      * @param content the actual text to copy to the board
      */
-    private fun copyToClipboard(label: String, content: String){
-        if(content.isBlank()) return
+    private fun copyToClipboard(label: String, content: String) {
+        if (content.isBlank()) return
 
         val activity = activity ?: return
         val view = view ?: return
@@ -474,7 +475,7 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
         val clipboard = activity.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         clipboard.primaryClip = ClipData.newPlainText(label, content)
 
-        activity.toast( view.context.getString(R.string.copied_to_clipboard, content.truncateCenter(20)),
+        activity.toast(view.context.getString(R.string.copied_to_clipboard, content.truncateCenter(20)),
                 Toast.LENGTH_SHORT)
     }
 
@@ -483,7 +484,7 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
      *
      * @param query the search query to pass to the search controller
      */
-    fun performGlobalSearch(query: String){
+    fun performGlobalSearch(query: String) {
         val router = parentController?.router ?: return
         router.pushController(CatalogueSearchController(query).withFadeTransaction())
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -250,6 +250,8 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
     fun setChapterCount(count: Float) {
         if (count > 0f) {
             manga_chapters?.text = DecimalFormat("#.#").format(count)
+        } else {
+            manga_chapters?.text = resources!!.getString(R.string.unknown)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.kt
@@ -37,7 +37,6 @@ object ChapterRecognition {
      */
     private val unwantedWhiteSpace = Regex("""(\s)(extra|special|omake)""")
 
-
     fun parseChapterNumber(chapter: SChapter, manga: SManga) {
         // If chapter number is known return.
         if (chapter.chapter_number == -2f || chapter.chapter_number > -1f)

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterRecognition.kt
@@ -11,7 +11,7 @@ object ChapterRecognition {
      * All cases with Ch.xx
      * Mokushiroku Alice Vol.1 Ch. 4: Misrepresentation -R> 4
      */
-    private val basic = Regex("""(?<=ch\.)([0-9]+)(\.[0-9]+)?(\.?[a-z]+)?""")
+    private val basic = Regex("""(?<=ch\.) *([0-9]+)(\.[0-9]+)?(\.?[a-z]+)?""")
 
     /**
      * Regex used when only one number occurrence
@@ -36,6 +36,7 @@ object ChapterRecognition {
      * Example One Piece 12 special -R> One Piece 12special
      */
     private val unwantedWhiteSpace = Regex("""(\s)(extra|special|omake)""")
+
 
     fun parseChapterNumber(chapter: SChapter, manga: SManga) {
         // If chapter number is known return.

--- a/app/src/test/java/eu/kanade/tachiyomi/data/database/ChapterRecognitionTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/database/ChapterRecognitionTest.kt
@@ -59,6 +59,17 @@ class ChapterRecognitionTest {
     }
 
     /**
+     * Ch. xx base case but space after period
+     */
+    @Test fun ChCaseBase2() {
+        createManga("Mokushiroku Alice")
+
+        createChapter("Mokushiroku Alice Vol. 1 Ch. 4: Misrepresentation")
+        ChapterRecognition.parseChapterNumber(chapter, manga)
+        assertThat(chapter.chapter_number).isEqualTo(4f)
+    }
+
+    /**
      * Ch.xx.x base case
      */
     @Test fun ChCaseDecimal() {


### PR DESCRIPTION
Wasnts matching on  vol. 1 ch. 10 previously so mangadex last chapter was showing volume number.

Changed details page to show blank instead of -1 or 0 for manga without chapters or with chapters but has no numbers like one shots.
Old  
![image](https://user-images.githubusercontent.com/2092019/35365660-c0513814-0143-11e8-99a5-21723319ede4.png)

New
![image](https://user-images.githubusercontent.com/2092019/35365551-2f7e98fe-0143-11e8-8969-09da7aeef8fd.png)