### PR TITLE
Added country/region support for locale when displayed for sources

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/LangHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/LangHolder.kt
@@ -2,21 +2,14 @@ package eu.kanade.tachiyomi.ui.catalogue
 
 import android.view.View
 import eu.davidea.flexibleadapter.FlexibleAdapter
-import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.base.holder.BaseFlexibleViewHolder
+import eu.kanade.tachiyomi.util.LocaleHelper
 import kotlinx.android.synthetic.main.catalogue_main_controller_card.*
-import java.util.*
 
 class LangHolder(view: View, adapter: FlexibleAdapter<*>) :
         BaseFlexibleViewHolder(view, adapter, true) {
 
     fun bind(item: LangItem) {
-        title.text = when {
-            item.code == "" -> itemView.context.getString(R.string.other_source)
-            else -> {
-                val locale = Locale(item.code)
-                locale.getDisplayName(locale).capitalize()
-            }
-        }
+        title.text = LocaleHelper.getDisplayName(item.code, itemView.context)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionDetailsController.kt
@@ -22,6 +22,7 @@ import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.online.LoginSource
 import eu.kanade.tachiyomi.ui.base.controller.NucleusController
 import eu.kanade.tachiyomi.ui.setting.preferenceCategory
+import eu.kanade.tachiyomi.util.LocaleHelper
 import eu.kanade.tachiyomi.widget.preference.LoginPreference
 import eu.kanade.tachiyomi.widget.preference.SourceLoginDialog
 import kotlinx.android.synthetic.main.extension_detail_controller.*
@@ -62,7 +63,7 @@ class ExtensionDetailsController(bundle: Bundle? = null) :
 
         extension_title.text = extension.name
         extension_version.text = context.getString(R.string.ext_version_info, extension.versionName)
-        extension_lang.text = context.getString(R.string.ext_language_info, extension.getLocalizedLang(context))
+        extension_lang.text = context.getString(R.string.ext_language_info, LocaleHelper.getDisplayName(extension.lang, context))
         extension_pkg.text = extension.pkgName
         extension.getApplicationIcon(context)?.let { extension_icon.setImageDrawable(it) }
         extension_uninstall_button.clicks().subscribeUntilDestroy {
@@ -122,8 +123,8 @@ class ExtensionDetailsController(bundle: Bundle? = null) :
         val dataStore = SharedPreferencesDataStore(/*if (source is HttpSource) {
             source.preferences
         } else {*/
-            context.getSharedPreferences("source_${source.id}", Context.MODE_PRIVATE)
-        /*}*/)
+                context.getSharedPreferences("source_${source.id}", Context.MODE_PRIVATE)
+                /*}*/)
 
         if (source is ConfigurableSource) {
             if (multiSource) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionHolder.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.extension.model.Extension
 import eu.kanade.tachiyomi.extension.model.InstallStep
 import eu.kanade.tachiyomi.ui.base.holder.BaseFlexibleViewHolder
 import eu.kanade.tachiyomi.ui.base.holder.SlicedHolder
+import eu.kanade.tachiyomi.util.LocaleHelper
 import io.github.mthli.slice.Slice
 import kotlinx.android.synthetic.main.extension_card_item.*
 
@@ -35,7 +36,7 @@ class ExtensionHolder(view: View, override val adapter: ExtensionAdapter) :
         ext_title.text = extension.name
         version.text = extension.versionName
         lang.text = if (extension !is Extension.Untrusted) {
-            extension.getLocalizedLang(itemView.context)
+            LocaleHelper.getDisplayName(extension.lang, itemView.context)
         } else {
             itemView.context.getString(R.string.ext_untrusted).toUpperCase()
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionViewUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionViewUtils.kt
@@ -3,21 +3,7 @@ package eu.kanade.tachiyomi.ui.extension
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
-import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.extension.model.Extension
-import java.util.*
-
-fun Extension.getLocalizedLang(context: Context): String {
-    return when (lang) {
-        null -> ""
-        "" -> context.getString(R.string.other_source)
-        "all" -> context.getString(R.string.all_lang)
-        else -> {
-            val locale = Locale(lang)
-            locale.getDisplayName(locale).capitalize()
-        }
-    }
-}
 
 fun Extension.getApplicationIcon(context: Context): Drawable? {
     return try {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSourcesController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSourcesController.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.data.preference.getOrDefault
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.source.online.LoginSource
+import eu.kanade.tachiyomi.util.LocaleHelper
 import eu.kanade.tachiyomi.widget.preference.LoginCheckBoxPreference
 import eu.kanade.tachiyomi.widget.preference.SourceLoginDialog
 import eu.kanade.tachiyomi.widget.preference.SwitchPreferenceCategory
@@ -39,7 +40,7 @@ class SettingsSourcesController : SettingsController(),
             // Create a preference group and set initial state and change listener
             SwitchPreferenceCategory(context).apply {
                 preferenceScreen.addPreference(this)
-                title = Locale(lang).let { it.getDisplayLanguage(it).capitalize() }
+                title = LocaleHelper.getDisplayName(lang, context)
                 isPersistent = false
                 if (lang in activeLangsCodes) {
                     setChecked(true)

--- a/app/src/main/java/eu/kanade/tachiyomi/util/LocaleHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/LocaleHelper.kt
@@ -51,9 +51,7 @@ object LocaleHelper {
     }
 
     /**
-     * Returns the locale for the value stored in preferences, or null if it's system language.
-     *
-     * @param pref the string value stored in preferences.
+     * Returns Display name of a string language code
      */
     fun getDisplayName(lang: String?, context: Context): String {
         return when (lang) {
@@ -67,8 +65,11 @@ object LocaleHelper {
         }
     }
 
+    /*Return Locale from string language code
+
+     */
     private fun getLocale(lang: String): Locale {
-        val sp = lang!!.split("_", "-")
+        val sp = lang.split("_", "-")
         return when (sp.size) {
             2 -> Locale(sp[0], sp[1])
             3 -> Locale(sp[0], sp[1], sp[2])

--- a/app/src/main/java/eu/kanade/tachiyomi/util/LocaleHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/LocaleHelper.kt
@@ -1,10 +1,12 @@
 package eu.kanade.tachiyomi.util
 
 import android.app.Application
+import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
 import android.os.LocaleList
 import android.view.ContextThemeWrapper
+import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import uy.kohesive.injekt.injectLazy
 import java.util.*
@@ -45,10 +47,33 @@ object LocaleHelper {
         if (pref.isNullOrEmpty()) {
             return null
         }
-        val parts = pref.split("_", "-")
-        val lang = parts[0]
-        val country = parts.getOrNull(1) ?: ""
-        return Locale(lang, country)
+        return getLocale(pref)
+    }
+
+    /**
+     * Returns the locale for the value stored in preferences, or null if it's system language.
+     *
+     * @param pref the string value stored in preferences.
+     */
+    fun getDisplayName(lang: String?, context: Context): String {
+        return when (lang) {
+            null -> ""
+            "" -> context.getString(R.string.other_source)
+            "all" -> context.getString(R.string.all_lang)
+            else -> {
+                val locale = getLocale(lang)
+                locale.getDisplayName(locale).capitalize()
+            }
+        }
+    }
+
+    private fun getLocale(lang: String): Locale {
+        val sp = lang!!.split("_", "-")
+        return when (sp.size) {
+            2 -> Locale(sp[0], sp[1])
+            3 -> Locale(sp[0], sp[1], sp[2])
+            else -> Locale(lang)
+        }
     }
 
     /**


### PR DESCRIPTION
Adjusted locale from external sources and catalogues to use the same code.  Originally was planning to use it an kotlin extension but decided to stuff in in the Locale Helper for consistency sake.  