### PR TITLE
Kitsu Fix

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuModels.kt
@@ -15,7 +15,7 @@ open class KitsuManga(obj: JsonObject) {
     val original by obj["attributes"].obj["posterImage"].byString
     val synopsis by obj["attributes"].byString
     val startDate = obj["attributes"].obj.get("startDate").nullString.orEmpty()
-    val status = obj["attributes"].obj.get("status").nullString.orEmpty()
+    open val status = obj["attributes"].obj.get("status").nullString.orEmpty()
 
     @CallSuper
     open fun toTrack() = TrackSearch.create(TrackManager.KITSU).apply {
@@ -33,7 +33,7 @@ open class KitsuManga(obj: JsonObject) {
 
 class KitsuLibManga(obj: JsonObject, manga: JsonObject) : KitsuManga(manga) {
     val remoteId by obj.byInt("id")
-    //override val status by obj["attributes"].byString
+    override val status by obj["attributes"].byString
     val ratingTwenty = obj["attributes"].obj.get("ratingTwenty").nullString
     val progress by obj["attributes"].byInt
 


### PR DESCRIPTION
@inorichi  now i remember why i had that override in 😄 

It would end up always throwing an exception when the user had the manga in kitsu but and try to sync it a manga in the library.

else -> throw Exception("Unknown status")

Caused because the first request returns status of the manga, whos values are different then the 2nd request which is read status