### PR TITLE
allow copyFrom to copy url from manga

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/SManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/SManga.kt
@@ -38,6 +38,9 @@ interface SManga : Serializable {
         if (other.thumbnail_url != null)
             thumbnail_url = other.thumbnail_url
 
+        if (other.url != null)
+            url = other.url
+
         status = other.status
 
         if (!initialized)


### PR DESCRIPTION
@inorichi 
Edit:  I might close this as i need to find another solution since this breaks restore.  Unless your fine with SMangaImpl being defaulted to blank instead of lateinit

this allows updating of the manga url when the source sets it.
 99% of time no source will set it.  I have to set it for Mangadex since they changed urls at some point from
/manga/153/

to 

/manga/153/detective-conan

the old url works, but when they added paging of chapters 
/manga/153/detective-conan/200 works
/manga/153/200 does not

so all the old urls need updated on the metadata refresh