### PR TITLE
Enable TLS 1.1 and TLS 1.2 on Android KitKat (and older)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -1,9 +1,22 @@
 package eu.kanade.tachiyomi.network
 
 import android.content.Context
+import android.os.Build
 import okhttp3.Cache
 import okhttp3.OkHttpClient
 import java.io.File
+import java.io.IOException
+import java.net.InetAddress
+import java.net.Socket
+import java.net.UnknownHostException
+import java.security.KeyManagementException
+import java.security.KeyStore
+import java.security.NoSuchAlgorithmException
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
 
 class NetworkHelper(context: Context) {
 
@@ -16,6 +29,73 @@ class NetworkHelper(context: Context) {
     val client = OkHttpClient.Builder()
             .cookieJar(cookieManager)
             .cache(Cache(cacheDir, cacheSize))
+            .apply {
+                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+                    val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+                    trustManagerFactory.init(null as KeyStore?)
+                    val trustManagers = trustManagerFactory.trustManagers
+                    if (trustManagers.size == 1 && trustManagers[0] is X509TrustManager) {
+                        class TLSSocketFactory @Throws(KeyManagementException::class, NoSuchAlgorithmException::class)
+                        constructor() : SSLSocketFactory() {
+
+                            private val internalSSLSocketFactory: SSLSocketFactory
+
+                            init {
+                                val context = SSLContext.getInstance("TLS")
+                                context.init(null, null, null)
+                                internalSSLSocketFactory = context.socketFactory
+                            }
+
+                            override fun getDefaultCipherSuites(): Array<String> {
+                                return internalSSLSocketFactory.defaultCipherSuites
+                            }
+
+                            override fun getSupportedCipherSuites(): Array<String> {
+                                return internalSSLSocketFactory.supportedCipherSuites
+                            }
+
+                            @Throws(IOException::class)
+                            override fun createSocket(): Socket? {
+                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket())
+                            }
+
+                            @Throws(IOException::class)
+                            override fun createSocket(s: Socket, host: String, port: Int, autoClose: Boolean): Socket? {
+                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket(s, host, port, autoClose))
+                            }
+
+                            @Throws(IOException::class, UnknownHostException::class)
+                            override fun createSocket(host: String, port: Int): Socket? {
+                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port))
+                            }
+
+                            @Throws(IOException::class, UnknownHostException::class)
+                            override fun createSocket(host: String, port: Int, localHost: InetAddress, localPort: Int): Socket? {
+                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port, localHost, localPort))
+                            }
+
+                            @Throws(IOException::class)
+                            override fun createSocket(host: InetAddress, port: Int): Socket? {
+                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port))
+                            }
+
+                            @Throws(IOException::class)
+                            override fun createSocket(address: InetAddress, port: Int, localAddress: InetAddress, localPort: Int): Socket? {
+                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket(address, port, localAddress, localPort))
+                            }
+
+                            private fun enableTLSOnSocket(socket: Socket?): Socket? {
+                                if (socket != null && socket is SSLSocket) {
+                                    socket.enabledProtocols = arrayOf("TLSv1", "TLSv1.1", "TLSv1.2")
+                                }
+                                return socket
+                            }
+                        }
+
+                        sslSocketFactory(TLSSocketFactory(), trustManagers[0] as X509TrustManager)
+                    }
+                }
+            }
             .build()
 
     val cloudflareClient = client.newBuilder()

--- a/app/src/main/java/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -86,7 +86,7 @@ class NetworkHelper(context: Context) {
 
                             private fun enableTLSOnSocket(socket: Socket?): Socket? {
                                 if (socket != null && socket is SSLSocket) {
-                                    socket.enabledProtocols = arrayOf("TLSv1", "TLSv1.1", "TLSv1.2")
+                                    socket.enabledProtocols = socket.supportedProtocols
                                 }
                                 return socket
                             }

--- a/app/src/main/java/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -29,73 +29,7 @@ class NetworkHelper(context: Context) {
     val client = OkHttpClient.Builder()
             .cookieJar(cookieManager)
             .cache(Cache(cacheDir, cacheSize))
-            .apply {
-                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-                    val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
-                    trustManagerFactory.init(null as KeyStore?)
-                    val trustManagers = trustManagerFactory.trustManagers
-                    if (trustManagers.size == 1 && trustManagers[0] is X509TrustManager) {
-                        class TLSSocketFactory @Throws(KeyManagementException::class, NoSuchAlgorithmException::class)
-                        constructor() : SSLSocketFactory() {
-
-                            private val internalSSLSocketFactory: SSLSocketFactory
-
-                            init {
-                                val context = SSLContext.getInstance("TLS")
-                                context.init(null, null, null)
-                                internalSSLSocketFactory = context.socketFactory
-                            }
-
-                            override fun getDefaultCipherSuites(): Array<String> {
-                                return internalSSLSocketFactory.defaultCipherSuites
-                            }
-
-                            override fun getSupportedCipherSuites(): Array<String> {
-                                return internalSSLSocketFactory.supportedCipherSuites
-                            }
-
-                            @Throws(IOException::class)
-                            override fun createSocket(): Socket? {
-                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket())
-                            }
-
-                            @Throws(IOException::class)
-                            override fun createSocket(s: Socket, host: String, port: Int, autoClose: Boolean): Socket? {
-                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket(s, host, port, autoClose))
-                            }
-
-                            @Throws(IOException::class, UnknownHostException::class)
-                            override fun createSocket(host: String, port: Int): Socket? {
-                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port))
-                            }
-
-                            @Throws(IOException::class, UnknownHostException::class)
-                            override fun createSocket(host: String, port: Int, localHost: InetAddress, localPort: Int): Socket? {
-                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port, localHost, localPort))
-                            }
-
-                            @Throws(IOException::class)
-                            override fun createSocket(host: InetAddress, port: Int): Socket? {
-                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port))
-                            }
-
-                            @Throws(IOException::class)
-                            override fun createSocket(address: InetAddress, port: Int, localAddress: InetAddress, localPort: Int): Socket? {
-                                return enableTLSOnSocket(internalSSLSocketFactory.createSocket(address, port, localAddress, localPort))
-                            }
-
-                            private fun enableTLSOnSocket(socket: Socket?): Socket? {
-                                if (socket != null && socket is SSLSocket) {
-                                    socket.enabledProtocols = socket.supportedProtocols
-                                }
-                                return socket
-                            }
-                        }
-
-                        sslSocketFactory(TLSSocketFactory(), trustManagers[0] as X509TrustManager)
-                    }
-                }
-            }
+            .enableTLS12()
             .build()
 
     val cloudflareClient = client.newBuilder()
@@ -105,4 +39,75 @@ class NetworkHelper(context: Context) {
     val cookies: PersistentCookieStore
         get() = cookieManager.store
 
+    private fun OkHttpClient.Builder.enableTLS12(): OkHttpClient.Builder {
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
+            return this
+        }
+
+        val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        trustManagerFactory.init(null as KeyStore?)
+        val trustManagers = trustManagerFactory.trustManagers
+        if (trustManagers.size == 1 && trustManagers[0] is X509TrustManager) {
+            class TLSSocketFactory @Throws(KeyManagementException::class, NoSuchAlgorithmException::class)
+            constructor() : SSLSocketFactory() {
+
+                private val internalSSLSocketFactory: SSLSocketFactory
+
+                init {
+                    val context = SSLContext.getInstance("TLS")
+                    context.init(null, null, null)
+                    internalSSLSocketFactory = context.socketFactory
+                }
+
+                override fun getDefaultCipherSuites(): Array<String> {
+                    return internalSSLSocketFactory.defaultCipherSuites
+                }
+
+                override fun getSupportedCipherSuites(): Array<String> {
+                    return internalSSLSocketFactory.supportedCipherSuites
+                }
+
+                @Throws(IOException::class)
+                override fun createSocket(): Socket? {
+                    return enableTLSOnSocket(internalSSLSocketFactory.createSocket())
+                }
+
+                @Throws(IOException::class)
+                override fun createSocket(s: Socket, host: String, port: Int, autoClose: Boolean): Socket? {
+                    return enableTLSOnSocket(internalSSLSocketFactory.createSocket(s, host, port, autoClose))
+                }
+
+                @Throws(IOException::class, UnknownHostException::class)
+                override fun createSocket(host: String, port: Int): Socket? {
+                    return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port))
+                }
+
+                @Throws(IOException::class, UnknownHostException::class)
+                override fun createSocket(host: String, port: Int, localHost: InetAddress, localPort: Int): Socket? {
+                    return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port, localHost, localPort))
+                }
+
+                @Throws(IOException::class)
+                override fun createSocket(host: InetAddress, port: Int): Socket? {
+                    return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port))
+                }
+
+                @Throws(IOException::class)
+                override fun createSocket(address: InetAddress, port: Int, localAddress: InetAddress, localPort: Int): Socket? {
+                    return enableTLSOnSocket(internalSSLSocketFactory.createSocket(address, port, localAddress, localPort))
+                }
+
+                private fun enableTLSOnSocket(socket: Socket?): Socket? {
+                    if (socket != null && socket is SSLSocket) {
+                        socket.enabledProtocols = socket.supportedProtocols
+                    }
+                    return socket
+                }
+            }
+
+            sslSocketFactory(TLSSocketFactory(), trustManagers[0] as X509TrustManager)
+        }
+
+        return this
+    }
 }


### PR DESCRIPTION
This fixes connection errors with some servers on Android 4.1-4.4. In particular I noticed this with the _xkcd_ extension.

More info on https://blog.dev-area.net/2015/08/13/android-4-1-enable-tls-1-1-and-tls-1-2/

