### PR TITLE
Implement Anilist API v2 (closes #1159)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -132,7 +132,6 @@ dependencies {
     // Network client
     implementation "com.squareup.okhttp3:okhttp:3.9.1"
     implementation 'com.squareup.okio:okio:1.14.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0-SNAPSHOT'
 
     // REST
     final retrofit_version = '2.3.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -234,7 +234,7 @@ dependencies {
 }
 
 buildscript {
-    ext.kotlin_version = '1.2.40'
+    ext.kotlin_version = '1.2.30'
     repositories {
         mavenCentral()
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -132,6 +132,7 @@ dependencies {
     // Network client
     implementation "com.squareup.okhttp3:okhttp:3.9.1"
     implementation 'com.squareup.okio:okio:1.14.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.11.0-SNAPSHOT'
 
     // REST
     final retrofit_version = '2.3.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -234,7 +234,7 @@ dependencies {
 }
 
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.2.40'
     repositories {
         mavenCentral()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupManager.kt
@@ -402,8 +402,11 @@ class BackupManager(val context: Context, version: Int = CURRENT_VERSION) {
                 for (dbTrack in dbTracks) {
                     if (track.sync_id == dbTrack.sync_id) {
                         // The sync is already in the db, only update its fields
-                        if (track.remote_id != dbTrack.remote_id) {
-                            dbTrack.remote_id = track.remote_id
+                        if (track.media_id != dbTrack.media_id) {
+                            dbTrack.media_id = track.media_id
+                        }
+                        if (track.library_id != dbTrack.library_id) {
+                            dbTrack.library_id = track.library_id
                         }
                         dbTrack.last_chapter_read = Math.max(dbTrack.last_chapter_read, track.last_chapter_read)
                         isInDatabase = true

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/serializer/TrackTypeAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/serializer/TrackTypeAdapter.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.data.backup.serializer
 
+import android.telecom.DisconnectCause.REMOTE
 import com.github.salomonbrys.kotson.typeAdapter
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonToken
@@ -11,7 +12,8 @@ import eu.kanade.tachiyomi.data.database.models.TrackImpl
 object TrackTypeAdapter {
 
     private const val SYNC = "s"
-    private const val REMOTE = "r"
+    private const val MEDIA = "m"
+    private const val LIBRARY = "ml"
     private const val TITLE = "t"
     private const val LAST_READ = "l"
     private const val TRACKING_URL = "u"
@@ -24,8 +26,10 @@ object TrackTypeAdapter {
                 value(it.title)
                 name(SYNC)
                 value(it.sync_id)
-                name(REMOTE)
-                value(it.remote_id)
+                name(MEDIA)
+                value(it.media_id)
+                name(LIBRARY)
+                value(it.library_id)
                 name(LAST_READ)
                 value(it.last_chapter_read)
                 name(TRACKING_URL)
@@ -43,7 +47,8 @@ object TrackTypeAdapter {
                         when (name) {
                             TITLE -> track.title = nextString()
                             SYNC -> track.sync_id = nextInt()
-                            REMOTE -> track.remote_id = nextInt()
+                            MEDIA -> track.media_id = nextInt()
+                            LIBRARY -> track.library_id = nextLong()
                             LAST_READ -> track.last_chapter_read = nextInt()
                             TRACKING_URL -> track.tracking_url = nextString()
                         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/serializer/TrackTypeAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/serializer/TrackTypeAdapter.kt
@@ -12,7 +12,7 @@ import eu.kanade.tachiyomi.data.database.models.TrackImpl
 object TrackTypeAdapter {
 
     private const val SYNC = "s"
-    private const val MEDIA = "m"
+    private const val MEDIA = "r"
     private const val LIBRARY = "ml"
     private const val TITLE = "t"
     private const val LAST_READ = "l"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenHelper.kt
@@ -58,10 +58,7 @@ class DbOpenHelper(context: Context)
             db.execSQL(TrackTable.addTrackingUrl)
         }
         if (oldVersion < 7) {
-            db.execSQL(TrackTable.copyOldTable)
-            db.execSQL(TrackTable.createTableQuery)
-            db.execSQL(TrackTable.copyOldData)
-            db.execSQL(TrackTable.dropOldTable)
+            db.execSQL(TrackTable.addLibraryId)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenHelper.kt
@@ -17,7 +17,7 @@ class DbOpenHelper(context: Context)
         /**
          * Version of the database.
          */
-        const val DATABASE_VERSION = 6
+        const val DATABASE_VERSION = 7
     }
 
     override fun onCreate(db: SQLiteDatabase) = with(db) {
@@ -56,6 +56,12 @@ class DbOpenHelper(context: Context)
         }
         if (oldVersion < 6) {
             db.execSQL(TrackTable.addTrackingUrl)
+        }
+        if (oldVersion < 7) {
+            db.execSQL(TrackTable.copyOldTable)
+            db.execSQL(TrackTable.createTableQuery)
+            db.execSQL(TrackTable.copyOldData)
+            db.execSQL(TrackTable.dropOldTable)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/mappers/TrackTypeMapping.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/mappers/TrackTypeMapping.kt
@@ -13,8 +13,9 @@ import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.database.models.TrackImpl
 import eu.kanade.tachiyomi.data.database.tables.TrackTable.COL_ID
 import eu.kanade.tachiyomi.data.database.tables.TrackTable.COL_LAST_CHAPTER_READ
+import eu.kanade.tachiyomi.data.database.tables.TrackTable.COL_LIBRARY_ID
 import eu.kanade.tachiyomi.data.database.tables.TrackTable.COL_MANGA_ID
-import eu.kanade.tachiyomi.data.database.tables.TrackTable.COL_REMOTE_ID
+import eu.kanade.tachiyomi.data.database.tables.TrackTable.COL_MEDIA_ID
 import eu.kanade.tachiyomi.data.database.tables.TrackTable.COL_SCORE
 import eu.kanade.tachiyomi.data.database.tables.TrackTable.COL_STATUS
 import eu.kanade.tachiyomi.data.database.tables.TrackTable.COL_SYNC_ID
@@ -45,7 +46,8 @@ class TrackPutResolver : DefaultPutResolver<Track>() {
         put(COL_ID, obj.id)
         put(COL_MANGA_ID, obj.manga_id)
         put(COL_SYNC_ID, obj.sync_id)
-        put(COL_REMOTE_ID, obj.remote_id)
+        put(COL_MEDIA_ID, obj.media_id)
+        put(COL_LIBRARY_ID, obj.library_id)
         put(COL_TITLE, obj.title)
         put(COL_LAST_CHAPTER_READ, obj.last_chapter_read)
         put(COL_TOTAL_CHAPTERS, obj.total_chapters)
@@ -62,7 +64,8 @@ class TrackGetResolver : DefaultGetResolver<Track>() {
         id = cursor.getLong(cursor.getColumnIndex(COL_ID))
         manga_id = cursor.getLong(cursor.getColumnIndex(COL_MANGA_ID))
         sync_id = cursor.getInt(cursor.getColumnIndex(COL_SYNC_ID))
-        remote_id = cursor.getInt(cursor.getColumnIndex(COL_REMOTE_ID))
+        media_id = cursor.getInt(cursor.getColumnIndex(COL_MEDIA_ID))
+        library_id = cursor.getLong(cursor.getColumnIndex(COL_LIBRARY_ID))
         title = cursor.getString(cursor.getColumnIndex(COL_TITLE))
         last_chapter_read = cursor.getInt(cursor.getColumnIndex(COL_LAST_CHAPTER_READ))
         total_chapters = cursor.getInt(cursor.getColumnIndex(COL_TOTAL_CHAPTERS))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Track.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Track.kt
@@ -10,7 +10,9 @@ interface Track : Serializable {
 
     var sync_id: Int
 
-    var remote_id: Int
+    var media_id: Int
+
+    var library_id: Long?
 
     var title: String
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/TrackImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/TrackImpl.kt
@@ -8,7 +8,9 @@ class TrackImpl : Track {
 
     override var sync_id: Int = 0
 
-    override var remote_id: Int = 0
+    override var media_id: Int = 0
+
+    override var library_id: Long? = null
 
     override lateinit var title: String
 
@@ -30,13 +32,13 @@ class TrackImpl : Track {
 
         if (manga_id != other.manga_id) return false
         if (sync_id != other.sync_id) return false
-        return remote_id == other.remote_id
+        return media_id == other.media_id
     }
 
     override fun hashCode(): Int {
         var result = (manga_id xor manga_id.ushr(32)).toInt()
         result = 31 * result + sync_id
-        result = 31 * result + remote_id
+        result = 31 * result + media_id
         return result
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/TrackTable.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/TrackTable.kt
@@ -10,7 +10,7 @@ object TrackTable {
 
     const val COL_SYNC_ID = "sync_id"
 
-    const val COL_MEDIA_ID = "media_id"
+    const val COL_MEDIA_ID = "remote_id"
 
     const val COL_LIBRARY_ID = "library_id"
 
@@ -47,36 +47,6 @@ object TrackTable {
     val addTrackingUrl: String
         get() = "ALTER TABLE $TABLE ADD COLUMN $COL_TRACKING_URL TEXT DEFAULT ''"
 
-    val copyOldTable: String
-        get() = """
-           ALTER TABLE $TABLE RENAME TO backup
-        """
-    val copyOldData: String
-        get() = """
-            INSERT INTO $TABLE(
-            $COL_ID,
-            $COL_MANGA_ID,
-            $COL_SYNC_ID,
-            $COL_MEDIA_ID,
-            $COL_TITLE,
-            $COL_LAST_CHAPTER_READ,
-            $COL_TOTAL_CHAPTERS,
-            $COL_STATUS,
-            $COL_SCORE,
-            $COL_TRACKING_URL)
-            SELECT $COL_ID,
-            $COL_MANGA_ID,
-            $COL_SYNC_ID,
-            remote_id,
-            $COL_TITLE,
-            $COL_LAST_CHAPTER_READ,
-            $COL_TOTAL_CHAPTERS,
-            $COL_STATUS,
-            $COL_SCORE,
-            $COL_TRACKING_URL
-            FROM backup
-            """
-
-    val dropOldTable: String
-        get() = "DROP TABLE backup"
+    val addLibraryId: String
+        get() = "ALTER TABLE $TABLE ADD COLUMN $COL_LIBRARY_ID INTEGER NULL"
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/TrackTable.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/TrackTable.kt
@@ -10,7 +10,9 @@ object TrackTable {
 
     const val COL_SYNC_ID = "sync_id"
 
-    const val COL_REMOTE_ID = "remote_id"
+    const val COL_MEDIA_ID = "media_id"
+
+    const val COL_LIBRARY_ID = "library_id"
 
     const val COL_TITLE = "title"
 
@@ -29,7 +31,8 @@ object TrackTable {
             $COL_ID INTEGER NOT NULL PRIMARY KEY,
             $COL_MANGA_ID INTEGER NOT NULL,
             $COL_SYNC_ID INTEGER NOT NULL,
-            $COL_REMOTE_ID INTEGER NOT NULL,
+            $COL_MEDIA_ID INTEGER NOT NULL,
+            $COL_LIBRARY_ID INTEGER,
             $COL_TITLE TEXT NOT NULL,
             $COL_LAST_CHAPTER_READ INTEGER NOT NULL,
             $COL_TOTAL_CHAPTERS INTEGER NOT NULL,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/TrackTable.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/TrackTable.kt
@@ -46,4 +46,37 @@ object TrackTable {
 
     val addTrackingUrl: String
         get() = "ALTER TABLE $TABLE ADD COLUMN $COL_TRACKING_URL TEXT DEFAULT ''"
+
+    val copyOldTable: String
+        get() = """
+           ALTER TABLE $TABLE RENAME TO backup
+        """
+    val copyOldData: String
+        get() = """
+            INSERT INTO $TABLE(
+            $COL_ID,
+            $COL_MANGA_ID,
+            $COL_SYNC_ID,
+            $COL_MEDIA_ID,
+            $COL_TITLE,
+            $COL_LAST_CHAPTER_READ,
+            $COL_TOTAL_CHAPTERS,
+            $COL_STATUS,
+            $COL_SCORE,
+            $COL_TRACKING_URL)
+            SELECT $COL_ID,
+            $COL_MANGA_ID,
+            $COL_SYNC_ID,
+            remote_id,
+            $COL_TITLE,
+            $COL_LAST_CHAPTER_READ,
+            $COL_TOTAL_CHAPTERS,
+            $COL_STATUS,
+            $COL_SCORE,
+            $COL_TRACKING_URL
+            FROM backup
+            """
+
+    val dropOldTable: String
+        get() = "DROP TABLE backup"
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -119,7 +119,7 @@ class PreferencesHelper(val context: Context) {
 
     fun trackToken(sync: TrackService) = rxPrefs.getString(Keys.trackToken(sync.id), "")
 
-    fun anilistScoreType() = rxPrefs.getInteger("anilist_score_type", 0)
+    fun anilistScoreType() = rxPrefs.getString("anilist_score_type", "POINT_10")
 
     fun backupsDirectory() = rxPrefs.getString(Keys.backupDirectory, defaultBackupDir.toString())
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.data.track.anilist
 
 import android.content.Context
 import android.graphics.Color
+import com.google.gson.Gson
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.preference.getOrDefault
@@ -9,6 +10,7 @@ import eu.kanade.tachiyomi.data.track.TrackService
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import rx.Completable
 import rx.Observable
+import uy.kohesive.injekt.injectLazy
 
 class Anilist(private val context: Context, id: Int) : TrackService(id) {
 
@@ -17,15 +19,24 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
         const val COMPLETED = 2
         const val ON_HOLD = 3
         const val DROPPED = 4
-        const val PLAN_TO_READ = 5
+        const val PLANNING = 5
+        const val REPEATING = 6
 
         const val DEFAULT_STATUS = READING
         const val DEFAULT_SCORE = 0
+
+        const val POINT_100 = "POINT_100"
+        const val POINT_10 = "POINT_10"
+        const val POINT_10_DECIMAL = "POINT_10_DECIMAL"
+        const val POINT_5 = "POINT_5"
+        const val POINT_3 = "POINT_3"
     }
 
     override val name = "AniList"
 
-    private val interceptor by lazy { AnilistInterceptor(getPassword()) }
+    private val gson: Gson by injectLazy()
+
+    private val interceptor by lazy { AnilistInterceptor(this, getPassword()) }
 
     private val api by lazy { AnilistApi(client, interceptor) }
 
@@ -34,7 +45,7 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
     override fun getLogoColor() = Color.rgb(18, 25, 35)
 
     override fun getStatusList(): List<Int> {
-        return listOf(READING, COMPLETED, ON_HOLD, DROPPED, PLAN_TO_READ)
+        return listOf(READING, COMPLETED, ON_HOLD, DROPPED, PLANNING, REPEATING)
     }
 
     override fun getStatus(status: Int): String = with(context) {
@@ -43,7 +54,8 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
             COMPLETED -> getString(R.string.completed)
             ON_HOLD -> getString(R.string.on_hold)
             DROPPED -> getString(R.string.dropped)
-            PLAN_TO_READ -> getString(R.string.plan_to_read)
+            PLANNING -> getString(R.string.plan_to_read)
+            REPEATING -> getString(R.string.repeating)
             else -> ""
         }
     }
@@ -51,15 +63,15 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
     override fun getScoreList(): List<String> {
         return when (preferences.anilistScoreType().getOrDefault()) {
             // 10 point
-            0 -> IntRange(0, 10).map(Int::toString)
+            POINT_10 -> IntRange(0, 10).map(Int::toString)
             // 100 point
-            1 -> IntRange(0, 100).map(Int::toString)
+            POINT_100 -> IntRange(0, 100).map(Int::toString)
             // 5 stars
-            2 -> IntRange(0, 5).map { "$it ★" }
+            POINT_5 -> IntRange(0, 5).map { "$it ★" }
             // Smiley
-            3 -> listOf("-", "😦", "😐", "😊")
+            POINT_3 -> listOf("-", "😦", "😐", "😊")
             // 10 point decimal
-            4 -> IntRange(0, 100).map { (it / 10f).toString() }
+            POINT_10_DECIMAL -> IntRange(0, 100).map { (it / 10f).toString() }
             else -> throw Exception("Unknown score type")
         }
     }
@@ -67,15 +79,15 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
     override fun indexToScore(index: Int): Float {
         return when (preferences.anilistScoreType().getOrDefault()) {
             // 10 point
-            0 -> index * 10f
+            POINT_10 -> index * 10f
             // 100 point
-            1 -> index.toFloat()
+            POINT_100 -> index.toFloat()
             // 5 stars
-            2 -> index * 20f
+            POINT_5 -> index * 20f
             // Smiley
-            3 -> index * 30f
+            POINT_3 -> index * 30f
             // 10 point decimal
-            4 -> index.toFloat()
+            POINT_10_DECIMAL -> index.toFloat()
             else -> throw Exception("Unknown score type")
         }
     }
@@ -83,8 +95,8 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
     override fun displayScore(track: Track): String {
         val score = track.score
         return when (preferences.anilistScoreType().getOrDefault()) {
-            2 -> "${(score / 20).toInt()} ★"
-            3 -> when {
+            POINT_5 -> "${(score / 20).toInt()} ★"
+            POINT_3 -> when {
                 score == 0f -> "0"
                 score <= 30 -> "😦"
                 score <= 60 -> "😐"
@@ -107,10 +119,11 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
     }
 
     override fun bind(track: Track): Observable<Track> {
-        return api.findLibManga(track, getUsername())
+        return api.findLibManga(track, getUsername().toInt())
                 .flatMap { remoteTrack ->
                     if (remoteTrack != null) {
                         track.copyPersonalFrom(remoteTrack)
+                        track.id = remoteTrack.id
                         update(track)
                     } else {
                         // Set default fields if it's not found in the list
@@ -126,7 +139,7 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
     }
 
     override fun refresh(track: Track): Observable<Track> {
-        return api.getLibManga(track, getUsername())
+        return api.getLibManga(track, getUsername().toInt())
                 .map { remoteTrack ->
                     track.copyPersonalFrom(remoteTrack)
                     track.total_chapters = remoteTrack.total_chapters
@@ -136,25 +149,33 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
 
     override fun login(username: String, password: String) = login(password)
 
-    fun login(authCode: String): Completable {
-        return api.login(authCode)
-                // Save the token in the interceptor.
-                .doOnNext { interceptor.setAuth(it) }
-                // Obtain the authenticated user from the API.
-                .zipWith(api.getCurrentUser().map { pair ->
-                    preferences.anilistScoreType().set(pair.second)
-                    pair.first
-                }, { oauth, user -> Pair(user, oauth.refresh_token!!) })
-                // Save service credentials (username and refresh token).
-                .doOnNext { saveCredentials(it.first, it.second) }
-                // Logout on any error.
-                .doOnError { logout() }
-                .toCompletable()
+    fun login(token: String): Completable{
+        val oauth = api.login(token)
+        interceptor.setAuth(oauth)
+        return api.getCurrentUser().map { pair ->
+            preferences.anilistScoreType().set(pair.second)
+            saveCredentials(pair.first.toString(), oauth.access_token)
+         }.doOnError{
+            logout()
+        }.toCompletable()
     }
 
     override fun logout() {
         super.logout()
+        preferences.trackToken(this).set(null)
         interceptor.setAuth(null)
+    }
+
+    fun saveOAuth(oAuth: OAuth?){
+        preferences.trackToken(this).set(gson.toJson(oAuth))
+    }
+
+    fun loadOAuth() : OAuth? {
+        return try{
+            gson.fromJson(preferences.trackToken(this).get(), OAuth::class.java)
+        } catch (e: Exception){
+            null
+        }
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -123,7 +123,7 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
                 .flatMap { remoteTrack ->
                     if (remoteTrack != null) {
                         track.copyPersonalFrom(remoteTrack)
-                        track.id = remoteTrack.id
+                        track.library_id = remoteTrack.library_id
                         update(track)
                     } else {
                         // Set default fields if it's not found in the list

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -149,12 +149,12 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
 
     override fun login(username: String, password: String) = login(password)
 
-    fun login(token: String): Completable{
-        val oauth = api.login(token)
+    fun login(token: String): Completable {
+        val oauth = api.createOAuth(token)
         interceptor.setAuth(oauth)
-        return api.getCurrentUser().map { pair ->
-            preferences.anilistScoreType().set(pair.second)
-            saveCredentials(pair.first.toString(), oauth.access_token)
+        return api.getCurrentUser().map { (username, scoreType) ->
+            preferences.anilistScoreType().set(scoreType)
+            saveCredentials(username.toString(), oauth.access_token)
          }.doOnError{
             logout()
         }.toCompletable()
@@ -166,14 +166,14 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
         interceptor.setAuth(null)
     }
 
-    fun saveOAuth(oAuth: OAuth?){
+    fun saveOAuth(oAuth: OAuth?) {
         preferences.trackToken(this).set(gson.toJson(oAuth))
     }
 
-    fun loadOAuth() : OAuth? {
-        return try{
+    fun loadOAuth(): OAuth? {
+        return try {
             gson.fromJson(preferences.trackToken(this).get(), OAuth::class.java)
-        } catch (e: Exception){
+        } catch (e: Exception) {
             null
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -45,6 +45,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                 .asObservableSuccess()
                 .map { netResponse ->
                     val responseBody = netResponse.body()?.string().orEmpty()
+                    netResponse.close()
                     if (responseBody.isEmpty()) {
                         throw Exception("Null Response")
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -19,7 +19,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
 
     private val parser = JsonParser()
     private val jsonMime = MediaType.parse("application/json; charset=utf-8")
-    private val authClient = client.newBuilder().addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY)).addInterceptor(interceptor).build()
+    private val authClient = client.newBuilder().addInterceptor(interceptor).build()
 
 
     fun addLibManga(track: Track): Observable<Track> {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -1,167 +1,305 @@
 package eu.kanade.tachiyomi.data.track.anilist
 
 import android.net.Uri
-import com.github.salomonbrys.kotson.int
-import com.github.salomonbrys.kotson.string
+import com.github.salomonbrys.kotson.*
 import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
-import eu.kanade.tachiyomi.network.POST
-import okhttp3.FormBody
+import eu.kanade.tachiyomi.network.asObservableSuccess
+import okhttp3.MediaType
 import okhttp3.OkHttpClient
-import okhttp3.ResponseBody
-import retrofit2.Response
-import retrofit2.Retrofit
-import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory
-import retrofit2.converter.gson.GsonConverterFactory
-import retrofit2.http.*
+import okhttp3.Request
+import okhttp3.RequestBody
 import rx.Observable
+
 
 class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
 
-    private val rest = restBuilder()
-            .client(client.newBuilder().addInterceptor(interceptor).build())
-            .build()
-            .create(Rest::class.java)
+    private val parser = JsonParser()
+    private val json = MediaType.parse("application/json; charset=utf-8")
+    private val authClient = client.newBuilder().addInterceptor(interceptor).build()
+
 
     fun addLibManga(track: Track): Observable<Track> {
-        return rest.addLibManga(track.remote_id, track.last_chapter_read, track.toAnilistStatus())
-                .map { response ->
-                    response.body()?.close()
-                    if (!response.isSuccessful) {
-                        throw Exception("Could not add manga")
+        val query = """
+            mutation AddManga(${'$'}mangaId: Int, ${'$'}progress: Int, ${'$'}status: MediaListStatus) {
+                     SaveMediaListEntry (mediaId: ${'$'}mangaId, progress: ${'$'}progress, status: ${'$'}status)
+                     { id status } }
+                     """
+        val variables = jsonObject(
+                "mangaId" to track.remote_id,
+                "progress" to track.last_chapter_read,
+                "status" to track.toAnilistStatus()
+        )
+        val payload = jsonObject(
+                "query" to query,
+                "variables" to variables
+        )
+        val body = RequestBody.create(json, payload.toString())
+        val request = Request.Builder()
+                .url(apiUrl)
+                .post(body)
+                .build()
+        return authClient.newCall(request)
+                .asObservableSuccess()
+                .map { netResponse ->
+                    val responseBody = netResponse.body()?.string().orEmpty()
+                    if (responseBody.isEmpty()) {
+                        throw Exception("Null Response")
                     }
+                    val response = parser.parse(responseBody).obj
+                    val id = response["data"]["SaveMediaListEntry"]["id"].asLong
+                    track.id = id
                     track
                 }
     }
 
     fun updateLibManga(track: Track): Observable<Track> {
-        return rest.updateLibManga(track.remote_id, track.last_chapter_read, track.toAnilistStatus(),
-                track.toAnilistScore())
-                .map { response ->
-                    response.body()?.close()
-                    if (!response.isSuccessful) {
-                        throw Exception("Could not update manga")
+        val query = """
+            mutation UpdateManga(${'$'}listId: Int, ${'$'}progress: Int, ${'$'}status: MediaListStatus, ${'$'}score: Int) {
+                        SaveMediaListEntry (id: ${'$'}listId, progress: ${'$'}progress, status: ${'$'}status, scoreRaw: ${'$'}score) {
+                            id
+                            status
+                            progress
+                        }
+                    }
+            """
+        val variables = jsonObject(
+                "listId" to track.id,
+                "progress" to track.last_chapter_read,
+                "status" to track.toAnilistStatus(),
+                "score" to track.toAnilistScore()
+        )
+        val payload = jsonObject(
+                "query" to query,
+                "variables" to variables
+        )
+        val body = RequestBody.create(json, payload.toString())
+        val request = Request.Builder()
+                .url(apiUrl)
+                .post(body)
+                .build()
+        return authClient.newCall(request)
+                .asObservableSuccess()
+                .map { netResponse ->
+                    val responseBody = netResponse.body()?.string().orEmpty()
+                    if (responseBody.isEmpty()) {
+                        throw Exception("Null Response")
                     }
                     track
                 }
     }
 
-    fun search(query: String): Observable<List<TrackSearch>> {
-        return rest.search(query, 1)
-                .map { list ->
-                    list.filter { it.type != "Novel" }.map { it.toTrack() }
+    fun search(search: String): Observable<List<TrackSearch>> {
+        val query = """
+            query Search(${'$'}query: String) {
+                  Page (perPage: 25) {
+                    media(search: ${'$'}query, type: MANGA, format: MANGA) {
+                      id
+                      title {
+                        romaji
+                      }
+                      coverImage {
+                        large
+                      }
+                      format
+                      type
+                      averageScore
+                      status
+                      popularity
+                      chapters
+                      volumes
+                      genres
+                      startDate {
+                        year
+                        month
+                        day
+                      }
+                      endDate {
+                        year
+                        month
+                        day
+                      }
+                    }
+                  }
                 }
-                .onErrorReturn { emptyList() }
-    }
-
-    fun getList(username: String): Observable<List<Track>> {
-        return rest.getLib(username)
-                .map { lib ->
-                    lib.flatten().map { it.toTrack() }
+            """
+        val variables = jsonObject(
+                "query" to search
+        )
+        val payload = jsonObject(
+                "query" to query,
+                "variables" to variables
+        )
+        val body = RequestBody.create(json, payload.toString())
+        val request = Request.Builder()
+                .url(apiUrl)
+                .post(body)
+                .build()
+        return authClient.newCall(request)
+                .asObservableSuccess()
+                .map { netResponse ->
+                    val responseBody = netResponse.body()?.string().orEmpty()
+                    if (responseBody.isEmpty()) {
+                        throw Exception("Null Response")
+                    }
+                    val response = parser.parse(responseBody).obj
+                    val data = response["data"]!!.obj
+                    val page = data["Page"].obj
+                    val media = page["media"].array
+                    val entries = media.map { jsonToALManga(it.obj) }
+                    entries.map { it.toTrack() }
                 }
     }
 
-    fun findLibManga(track: Track, username: String) : Observable<Track?> {
-        // TODO avoid getting the entire list
-        return getList(username)
-                .map { list -> list.find { it.remote_id == track.remote_id } }
+
+    fun findLibManga(track: Track, userid: Int) : Observable<Track?> {
+        val query = """
+            query (${'$'}id: Int!, ${'$'}manga_id: Int!) {
+                  Page {
+                    mediaList(userId: ${'$'}id, type: MANGA, mediaId: ${'$'}manga_id) {
+                      id
+                      status
+                      score
+                      scoreRaw: score(format: POINT_100)
+                      progress
+                      progressVolumes
+                      media{
+                        id
+                        title {
+                          romaji
+                        }
+                      coverImage {
+                        large
+                      }
+                      format
+                      type
+                      averageScore
+                      status
+                      popularity
+                      chapters
+                      volumes
+                      genres
+                      startDate {
+                       year
+                       month
+                       day
+                       }
+                      endDate {
+                        year
+                        month
+                        day
+                      }
+                      }
+                    }
+                  }
+                }
+            """
+        val variables = jsonObject(
+                "id" to userid,
+                "manga_id" to track.remote_id
+        )
+        val payload = jsonObject(
+                "query" to query,
+                "variables" to variables
+        )
+        val body = RequestBody.create(json, payload.toString())
+        val request = Request.Builder()
+                .url(apiUrl)
+                .post(body)
+                .build()
+        return authClient.newCall(request)
+                .asObservableSuccess()
+                .map { netResponse ->
+                    val responseBody = netResponse.body()?.string().orEmpty()
+                    if (responseBody.isEmpty()) {
+                        throw Exception("Null Response")
+                    }
+                    val response = parser.parse(responseBody).obj
+                    val data = response["data"]!!.obj
+                    val page = data["Page"].obj
+                    val media = page["mediaList"].array
+                    val entries = media.map { jsonToALUserManga(it.obj) }
+                    if (entries.isEmpty()){
+                        null
+                    } else {
+                        entries[0].toTrack()
+                    }
+
+                }
     }
 
-    fun getLibManga(track: Track, username: String): Observable<Track> {
-        return findLibManga(track, username)
+    fun getLibManga(track: Track, userid: Int): Observable<Track> {
+        return findLibManga(track, userid)
                 .map { it ?: throw Exception("Could not find manga") }
     }
 
-    fun login(authCode: String): Observable<OAuth> {
-        return restBuilder()
-                .client(client)
+    fun login(token: String): OAuth {
+        return OAuth(token, "Bearer", System.currentTimeMillis() + 31536000000, 31536000000)
+    }
+
+    fun getCurrentUser(): Observable<Pair<Int, String>> {
+        val query = """
+            query User
+                {
+                  Viewer {
+                    id
+                    mediaListOptions {
+                      scoreFormat
+                    }
+                  }
+                }
+                """
+        val payload = jsonObject(
+                "query" to query
+        )
+        val body = RequestBody.create(json, payload.toString())
+        val request = Request.Builder()
+                .url(apiUrl)
+                .post(body)
                 .build()
-                .create(Rest::class.java)
-                .requestAccessToken(authCode)
+        return authClient.newCall(request)
+                .asObservableSuccess()
+                .map { netResponse ->
+                    val responseBody = netResponse.body()?.string().orEmpty()
+                    if (responseBody.isEmpty()) {
+                        throw Exception("Null Response")
+                    }
+                    val response = parser.parse(responseBody).obj
+                    val data = response["data"]!!.obj
+                    val viewer = data["Viewer"].obj
+                    Pair(viewer["id"].asInt, viewer["mediaListOptions"]["scoreFormat"].asString)
+                }
     }
 
-    fun getCurrentUser(): Observable<Pair<String, Int>> {
-        return rest.getCurrentUser()
-                .map { it["id"].string to it["score_type"].int }
+    fun jsonToALManga(struct: JsonObject): ALManga{
+        return ALManga(struct["id"].asInt, struct["title"]["romaji"].asString, struct["coverImage"]["large"].asString,
+                null, struct["type"].asString, struct["status"].asString,
+                struct["startDate"]["year"].nullString.orEmpty() + struct["startDate"]["month"].nullString.orEmpty()
+                        + struct["startDate"]["day"].nullString.orEmpty(), struct["chapters"].nullInt ?: 0)
     }
 
-    private fun restBuilder() = Retrofit.Builder()
-            .baseUrl(baseUrl)
-            .addConverterFactory(GsonConverterFactory.create())
-            .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
-
-    private interface Rest {
-
-        @FormUrlEncoded
-        @POST("auth/access_token")
-        fun requestAccessToken(
-                @Field("code") code: String,
-                @Field("grant_type") grant_type: String = "authorization_code",
-                @Field("client_id") client_id: String = clientId,
-                @Field("client_secret") client_secret: String = clientSecret,
-                @Field("redirect_uri") redirect_uri: String = clientUrl
-        ) : Observable<OAuth>
-
-        @GET("user")
-        fun getCurrentUser(): Observable<JsonObject>
-
-        @GET("manga/search/{query}")
-        fun search(
-                @Path("query") query: String,
-                @Query("page") page: Int
-        ): Observable<List<ALManga>>
-
-        @GET("user/{username}/mangalist")
-        fun getLib(
-                @Path("username") username: String
-        ): Observable<ALUserLists>
-
-        @FormUrlEncoded
-        @PUT("mangalist")
-        fun addLibManga(
-                @Field("id") id: Int,
-                @Field("chapters_read") chapters_read: Int,
-                @Field("list_status") list_status: String
-        ) : Observable<Response<ResponseBody>>
-
-        @FormUrlEncoded
-        @PUT("mangalist")
-        fun updateLibManga(
-                @Field("id") id: Int,
-                @Field("chapters_read") chapters_read: Int,
-                @Field("list_status") list_status: String,
-                @Field("score") score_raw: String
-        ) : Observable<Response<ResponseBody>>
-
+    fun jsonToALUserManga(struct: JsonObject): ALUserManga{
+        return ALUserManga(struct["id"].asInt, struct["status"].asString, struct["scoreRaw"].asInt, struct["progress"].asInt, jsonToALManga(struct["media"].obj) )
     }
+
 
     companion object {
-        private const val clientId = "tachiyomi-hrtje"
-        private const val clientSecret = "nlGB5OmgE9YWq5dr3gIDbTQV0C"
+        private const val clientId = "377"
         private const val clientUrl = "tachiyomi://anilist-auth"
-        private const val baseUrl = "https://anilist.co/api/"
+        private const val apiUrl = "https://graphql.anilist.co/"
+        private const val baseUrl = "https://anilist.co/api/v2/"
         private const val baseMangaUrl = "https://anilist.co/manga/"
 
         fun mangaUrl(remoteId: Int): String {
             return baseMangaUrl + remoteId
         }
 
-        fun authUrl() = Uri.parse("${baseUrl}auth/authorize").buildUpon()
-                .appendQueryParameter("grant_type", "authorization_code")
+        fun authUrl() = Uri.parse("${baseUrl}oauth/authorize").buildUpon()
                 .appendQueryParameter("client_id", clientId)
-                .appendQueryParameter("redirect_uri", clientUrl)
-                .appendQueryParameter("response_type", "code")
+                .appendQueryParameter("response_type", "token")
                 .build()
-
-        fun refreshTokenRequest(token: String) = POST("${baseUrl}auth/access_token",
-                body = FormBody.Builder()
-                        .add("grant_type", "refresh_token")
-                        .add("client_id", clientId)
-                        .add("client_secret", clientSecret)
-                        .add("refresh_token", token)
-                        .build())
-
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -17,7 +17,7 @@ import rx.Observable
 class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
 
     private val parser = JsonParser()
-    private val json = MediaType.parse("application/json; charset=utf-8")
+    private val jsonMime = MediaType.parse("application/json; charset=utf-8")
     private val authClient = client.newBuilder().addInterceptor(interceptor).build()
 
 
@@ -36,7 +36,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                 "query" to query,
                 "variables" to variables
         )
-        val body = RequestBody.create(json, payload.toString())
+        val body = RequestBody.create(jsonMime, payload.toString())
         val request = Request.Builder()
                 .url(apiUrl)
                 .post(body)
@@ -75,18 +75,14 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                 "query" to query,
                 "variables" to variables
         )
-        val body = RequestBody.create(json, payload.toString())
+        val body = RequestBody.create(jsonMime, payload.toString())
         val request = Request.Builder()
                 .url(apiUrl)
                 .post(body)
                 .build()
         return authClient.newCall(request)
                 .asObservableSuccess()
-                .map { netResponse ->
-                    val responseBody = netResponse.body()?.string().orEmpty()
-                    if (responseBody.isEmpty()) {
-                        throw Exception("Null Response")
-                    }
+                .map {
                     track
                 }
     }
@@ -103,20 +99,10 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                       coverImage {
                         large
                       }
-                      format
                       type
-                      averageScore
                       status
-                      popularity
                       chapters
-                      volumes
-                      genres
                       startDate {
-                        year
-                        month
-                        day
-                      }
-                      endDate {
                         year
                         month
                         day
@@ -132,7 +118,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                 "query" to query,
                 "variables" to variables
         )
-        val body = RequestBody.create(json, payload.toString())
+        val body = RequestBody.create(jsonMime, payload.toString())
         val request = Request.Builder()
                 .url(apiUrl)
                 .post(body)
@@ -161,10 +147,8 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     mediaList(userId: ${'$'}id, type: MANGA, mediaId: ${'$'}manga_id) {
                       id
                       status
-                      score
                       scoreRaw: score(format: POINT_100)
                       progress
-                      progressVolumes
                       media{
                         id
                         title {
@@ -173,24 +157,14 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                       coverImage {
                         large
                       }
-                      format
                       type
-                      averageScore
                       status
-                      popularity
                       chapters
-                      volumes
-                      genres
                       startDate {
                        year
                        month
                        day
                        }
-                      endDate {
-                        year
-                        month
-                        day
-                      }
                       }
                     }
                   }
@@ -204,7 +178,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                 "query" to query,
                 "variables" to variables
         )
-        val body = RequestBody.create(json, payload.toString())
+        val body = RequestBody.create(jsonMime, payload.toString())
         val request = Request.Builder()
                 .url(apiUrl)
                 .post(body)
@@ -221,11 +195,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     val page = data["Page"].obj
                     val media = page["mediaList"].array
                     val entries = media.map { jsonToALUserManga(it.obj) }
-                    if (entries.isEmpty()){
-                        null
-                    } else {
-                        entries[0].toTrack()
-                    }
+                    entries.firstOrNull()?.toTrack()
 
                 }
     }
@@ -235,7 +205,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                 .map { it ?: throw Exception("Could not find manga") }
     }
 
-    fun login(token: String): OAuth {
+    fun createOAuth(token: String): OAuth {
         return OAuth(token, "Bearer", System.currentTimeMillis() + 31536000000, 31536000000)
     }
 
@@ -254,7 +224,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         val payload = jsonObject(
                 "query" to query
         )
-        val body = RequestBody.create(json, payload.toString())
+        val body = RequestBody.create(jsonMime, payload.toString())
         val request = Request.Builder()
                 .url(apiUrl)
                 .post(body)
@@ -286,7 +256,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
 
 
     companion object {
-        private const val clientId = "377"
+        private const val clientId = "385"
         private const val clientUrl = "tachiyomi://anilist-auth"
         private const val apiUrl = "https://graphql.anilist.co/"
         private const val baseUrl = "https://anilist.co/api/v2/"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -11,7 +11,6 @@ import okhttp3.MediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
-import okhttp3.logging.HttpLoggingInterceptor
 import rx.Observable
 
 
@@ -70,7 +69,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                 "listId" to track.library_id,
                 "progress" to track.last_chapter_read,
                 "status" to track.toAnilistStatus(),
-                "score" to track.toAnilistScore()
+                "score" to track.score.toInt()
         )
         val payload = jsonObject(
                 "query" to query,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistInterceptor.kt
@@ -1,10 +1,10 @@
 package eu.kanade.tachiyomi.data.track.anilist
 
-import com.google.gson.Gson
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class AnilistInterceptor(private var refreshToken: String?) : Interceptor {
+
+class AnilistInterceptor(val anilist: Anilist, private var token: String?) : Interceptor {
 
     /**
      * OAuth object used for authenticated requests.
@@ -20,24 +20,20 @@ class AnilistInterceptor(private var refreshToken: String?) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
 
-        if (refreshToken.isNullOrEmpty()) {
+        if (token.isNullOrEmpty()) {
             throw Exception("Not authenticated with Anilist")
         }
-
+        if (oauth == null){
+            oauth = anilist.loadOAuth()
+        }
         // Refresh access token if null or expired.
-        if (oauth == null || oauth!!.isExpired()) {
-            val response = chain.proceed(AnilistApi.refreshTokenRequest(refreshToken!!))
-            oauth = if (response.isSuccessful) {
-                Gson().fromJson(response.body()!!.string(), OAuth::class.java)
-            } else {
-                response.close()
-                null
-            }
+        if (oauth!!.isExpired()) {
+            anilist.logout()
         }
 
         // Throw on null auth.
         if (oauth == null) {
-            throw Exception("Access token wasn't refreshed")
+            throw Exception("No authentication token")
         }
 
         // Add the authorization header to the original request.
@@ -53,8 +49,9 @@ class AnilistInterceptor(private var refreshToken: String?) : Interceptor {
      * and the oauth object.
      */
     fun setAuth(oauth: OAuth?) {
-        refreshToken = oauth?.refresh_token
+        token = oauth?.access_token
         this.oauth = oauth
+        anilist.saveOAuth(oauth)
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistInterceptor.kt
@@ -29,6 +29,7 @@ class AnilistInterceptor(val anilist: Anilist, private var token: String?) : Int
         // Refresh access token if null or expired.
         if (oauth!!.isExpired()) {
             anilist.logout()
+            throw Exception("Token expired")
         }
 
         // Throw on null auth.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistModels.kt
@@ -50,6 +50,7 @@ data class ALUserManga(
         val manga: ALManga) {
 
     fun toTrack() = Track.create(TrackManager.ANILIST).apply {
+        id = this@ALUserManga.id.toLong()
         remote_id = manga.id
         status = toTrackStatus()
         score = score_raw.toFloat()
@@ -57,11 +58,11 @@ data class ALUserManga(
     }
 
     fun toTrackStatus() = when (list_status) {
-        "reading" -> Anilist.READING
-        "completed" -> Anilist.COMPLETED
-        "on-hold" -> Anilist.ON_HOLD
-        "dropped" -> Anilist.DROPPED
-        "plan to read" -> Anilist.PLAN_TO_READ
+        "CURRENT" -> Anilist.READING
+        "COMPLETED" -> Anilist.COMPLETED
+        "PAUSED" -> Anilist.ON_HOLD
+        "DROPPED" -> Anilist.DROPPED
+        "PLANNING" -> Anilist.PLANNING
         else -> throw NotImplementedError("Unknown status")
     }
 }
@@ -72,11 +73,12 @@ data class ALUserLists(val lists: Map<String, List<ALUserManga>>) {
 }
 
 fun Track.toAnilistStatus() = when (status) {
-    Anilist.READING -> "reading"
-    Anilist.COMPLETED -> "completed"
-    Anilist.ON_HOLD -> "on-hold"
-    Anilist.DROPPED -> "dropped"
-    Anilist.PLAN_TO_READ -> "plan to read"
+    Anilist.READING -> "CURRENT"
+    Anilist.COMPLETED -> "COMPLETED"
+    Anilist.ON_HOLD -> "PAUSED"
+    Anilist.DROPPED -> "DROPPED"
+    Anilist.PLANNING -> "PLANNING"
+    Anilist.REPEATING -> "REPEATING"
     else -> throw NotImplementedError("Unknown status")
 }
 
@@ -84,11 +86,11 @@ private val preferences: PreferencesHelper by injectLazy()
 
 fun Track.toAnilistScore(): String = when (preferences.anilistScoreType().getOrDefault()) {
 // 10 point
-    0 -> (score.toInt() / 10).toString()
+    "POINT_10" -> (score.toInt() / 10).toString()
 // 100 point
-    1 -> score.toInt().toString()
+    "POINT_100" -> score.toInt().toString()
 // 5 stars
-    2 -> when {
+    "POINT_5" -> when {
         score == 0f -> "0"
         score < 30 -> "1"
         score < 50 -> "2"
@@ -97,13 +99,13 @@ fun Track.toAnilistScore(): String = when (preferences.anilistScoreType().getOrD
         else -> "5"
     }
 // Smiley
-    3 -> when {
+    "POINT_3" -> when {
         score == 0f -> "0"
         score <= 30 -> ":("
         score <= 60 -> ":|"
         else -> ":)"
     }
 // 10 point decimal
-    4 -> (score / 10).toString()
+    "POINT_10_DECIMAL" -> (score / 10).toString()
     else -> throw Exception("Unknown score type")
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistModels.kt
@@ -11,7 +11,7 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 data class ALManga(
-        val id: Int,
+        val media_id: Int,
         val title_romaji: String,
         val image_url_lge: String,
         val description: String?,
@@ -21,12 +21,12 @@ data class ALManga(
         val total_chapters: Int) {
 
     fun toTrack() = TrackSearch.create(TrackManager.ANILIST).apply {
-        remote_id = this@ALManga.id
+        media_id = this@ALManga.media_id
         title = title_romaji
         total_chapters = this@ALManga.total_chapters
         cover_url = image_url_lge
         summary = description ?: ""
-        tracking_url = AnilistApi.mangaUrl(remote_id)
+        tracking_url = AnilistApi.mangaUrl(media_id)
         publishing_status = this@ALManga.publishing_status
         publishing_type = type
         if (!start_date_fuzzy.isNullOrBlank()) {
@@ -43,18 +43,18 @@ data class ALManga(
 }
 
 data class ALUserManga(
-        val id: Int,
+        val library_id: Long,
         val list_status: String,
         val score_raw: Int,
         val chapters_read: Int,
         val manga: ALManga) {
 
     fun toTrack() = Track.create(TrackManager.ANILIST).apply {
-        id = this@ALUserManga.id.toLong()
-        remote_id = manga.id
+        media_id = manga.media_id
         status = toTrackStatus()
         score = score_raw.toFloat()
         last_chapter_read = chapters_read
+        library_id = this@ALUserManga.library_id
     }
 
     fun toTrackStatus() = when (list_status) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistModels.kt
@@ -67,11 +67,6 @@ data class ALUserManga(
     }
 }
 
-data class ALUserLists(val lists: Map<String, List<ALUserManga>>) {
-
-    fun flatten() = lists.values.flatten()
-}
-
 fun Track.toAnilistStatus() = when (status) {
     Anilist.READING -> "CURRENT"
     Anilist.COMPLETED -> "COMPLETED"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/OAuth.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/OAuth.kt
@@ -4,8 +4,7 @@ data class OAuth(
         val access_token: String,
         val token_type: String,
         val expires: Long,
-        val expires_in: Long,
-        val refresh_token: String?) {
+        val expires_in: Long) {
 
     fun isExpired() = System.currentTimeMillis() > expires
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
@@ -87,7 +87,7 @@ class Kitsu(private val context: Context, id: Int) : TrackService(id) {
                 .flatMap { remoteTrack ->
                     if (remoteTrack != null) {
                         track.copyPersonalFrom(remoteTrack)
-                        track.remote_id = remoteTrack.remote_id
+                        track.library_id = remoteTrack.library_id
                         update(track)
                     } else {
                         track.score = DEFAULT_SCORE

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
@@ -87,7 +87,7 @@ class Kitsu(private val context: Context, id: Int) : TrackService(id) {
                 .flatMap { remoteTrack ->
                     if (remoteTrack != null) {
                         track.copyPersonalFrom(remoteTrack)
-                        track.library_id = remoteTrack.library_id
+                        track.media_id = remoteTrack.media_id
                         update(track)
                     } else {
                         track.score = DEFAULT_SCORE

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuApi.kt
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.POST
-import eu.kanade.tachiyomi.util.SharedData.map
 import okhttp3.FormBody
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -64,7 +63,7 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
             // @formatter:off
             val data = jsonObject(
                     "type" to "libraryEntries",
-                    "id" to track.library_id,
+                    "id" to track.media_id,
                     "attributes" to jsonObject(
                             "status" to track.toKitsuStatus(),
                             "progress" to track.last_chapter_read,
@@ -73,7 +72,7 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
             )
             // @formatter:on
 
-            rest.updateLibManga(track.library_id ?: throw Exception("Library Id not found"), jsonObject("data" to data))
+            rest.updateLibManga(track.media_id, jsonObject("data" to data))
                     .map { track }
         }
     }
@@ -140,7 +139,7 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
         @Headers("Content-Type: application/vnd.api+json")
         @PATCH("library-entries/{id}")
         fun updateLibManga(
-                @Path("id") remoteId: Long,
+                @Path("id") remoteId: Int,
                 @Body data: JsonObject
         ): Observable<JsonObject>
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuModels.kt
@@ -32,13 +32,13 @@ open class KitsuManga(obj: JsonObject) {
 }
 
 class KitsuLibManga(obj: JsonObject, manga: JsonObject) : KitsuManga(manga) {
-    val libraryId by obj.byLong("id")
+    val libraryId by obj.byInt("id")
     override val status by obj["attributes"].byString
     val ratingTwenty = obj["attributes"].obj.get("ratingTwenty").nullString
     val progress by obj["attributes"].byInt
 
     override fun toTrack() = super.toTrack().apply {
-        library_id = libraryId
+        media_id = libraryId // TODO migrate media ids to library ids
         status = toTrackStatus()
         score = ratingTwenty?.let { it.toInt() / 2f } ?: 0f
         last_chapter_read = progress

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuModels.kt
@@ -19,12 +19,12 @@ open class KitsuManga(obj: JsonObject) {
 
     @CallSuper
     open fun toTrack() = TrackSearch.create(TrackManager.KITSU).apply {
-        remote_id = this@KitsuManga.id
+        media_id = this@KitsuManga.id
         title = canonicalTitle
         total_chapters = chapterCount ?: 0
         cover_url = original
         summary = synopsis
-        tracking_url = KitsuApi.mangaUrl(remote_id)
+        tracking_url = KitsuApi.mangaUrl(media_id)
         publishing_status = this@KitsuManga.status
         publishing_type = type
         start_date = startDate.orEmpty()
@@ -32,13 +32,13 @@ open class KitsuManga(obj: JsonObject) {
 }
 
 class KitsuLibManga(obj: JsonObject, manga: JsonObject) : KitsuManga(manga) {
-    val remoteId by obj.byInt("id")
+    val libraryId by obj.byLong("id")
     override val status by obj["attributes"].byString
     val ratingTwenty = obj["attributes"].obj.get("ratingTwenty").nullString
     val progress by obj["attributes"].byInt
 
     override fun toTrack() = super.toTrack().apply {
-        remote_id = remoteId
+        library_id = libraryId
         status = toTrackStatus()
         score = ratingTwenty?.let { it.toInt() / 2f } ?: 0f
         last_chapter_read = progress

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackSearch.kt
@@ -10,7 +10,9 @@ class TrackSearch : Track {
 
     override var sync_id: Int = 0
 
-    override var remote_id: Int = 0
+    override var media_id: Int = 0
+
+    override var library_id: Long? = null
 
     override lateinit var title: String
 
@@ -42,13 +44,13 @@ class TrackSearch : Track {
 
         if (manga_id != other.manga_id) return false
         if (sync_id != other.sync_id) return false
-        return remote_id == other.remote_id
+        return media_id == other.media_id
     }
 
     override fun hashCode(): Int {
         var result = (manga_id xor manga_id.ushr(32)).toInt()
         result = 31 * result + sync_id
-        result = 31 * result + remote_id
+        result = 31 * result + media_id
         return result
     }
     companion object {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyanimelistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyanimelistApi.kt
@@ -54,11 +54,11 @@ class MyanimelistApi(private val client: OkHttpClient, username: String, passwor
                     .map {
                         TrackSearch.create(TrackManager.MYANIMELIST).apply {
                             title = it.selectText("title")!!
-                            remote_id = it.selectInt("id")
+                            media_id = it.selectInt("id")
                             total_chapters = it.selectInt("chapters")
                             summary = it.selectText("synopsis")!!
                             cover_url = it.selectText("image")!!
-                            tracking_url = MyanimelistApi.mangaUrl(remote_id)
+                            tracking_url = MyanimelistApi.mangaUrl(media_id)
                             publishing_status = it.selectText("status")!!
                             publishing_type = it.selectText("type")!!
                             start_date = it.selectText("start_date")!!
@@ -77,13 +77,13 @@ class MyanimelistApi(private val client: OkHttpClient, username: String, passwor
                 .map {
                     TrackSearch.create(TrackManager.MYANIMELIST).apply {
                         title = it.selectText("series_title")!!
-                        remote_id = it.selectInt("series_mangadb_id")
+                        media_id = it.selectInt("series_mangadb_id")
                         last_chapter_read = it.selectInt("my_read_chapters")
                         status = it.selectInt("my_status")
                         score = it.selectInt("my_score").toFloat()
                         total_chapters = it.selectInt("series_chapters")
                         cover_url = it.selectText("series_image")!!
-                        tracking_url = MyanimelistApi.mangaUrl(remote_id)
+                        tracking_url = MyanimelistApi.mangaUrl(media_id)
                     }
                 }
                 .toList()
@@ -91,7 +91,7 @@ class MyanimelistApi(private val client: OkHttpClient, username: String, passwor
 
     fun findLibManga(track: Track, username: String): Observable<Track?> {
         return getList(username)
-                .map { list -> list.find { it.remote_id == track.remote_id } }
+                .map { list -> list.find { it.media_id == track.media_id } }
     }
 
     fun getLibManga(track: Track, username: String): Observable<Track> {
@@ -169,12 +169,12 @@ class MyanimelistApi(private val client: OkHttpClient, username: String, passwor
 
     fun getUpdateUrl(track: Track) = Uri.parse(baseUrl).buildUpon()
             .appendEncodedPath("api/mangalist/update")
-            .appendPath("${track.remote_id}.xml")
+            .appendPath("${track.media_id}.xml")
             .toString()
 
     fun getAddUrl(track: Track) = Uri.parse(baseUrl).buildUpon()
             .appendEncodedPath("api/mangalist/add")
-            .appendPath("${track.remote_id}.xml")
+            .appendPath("${track.media_id}.xml")
             .toString()
 
     fun createHeaders(username: String, password: String): Headers {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/AnilistLoginActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/AnilistLoginActivity.kt
@@ -23,13 +23,14 @@ class AnilistLoginActivity : AppCompatActivity() {
         val view = ProgressBar(this)
         setContentView(view, FrameLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT, CENTER))
 
-        val code = intent.data?.getQueryParameter("code")
-        if (code != null) {
-            trackManager.aniList.login(code)
+        val regex = "(?:access_token=)(.*?)(?:&)".toRegex()
+        val matchResult = regex.find(intent.data?.fragment.toString())
+        if (matchResult?.groups?.get(1) != null) {
+            trackManager.aniList.login(matchResult.groups[1]!!.value)
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe({
-                        returnToSettings()
+                      returnToSettings()
                     }, { _ ->
                         returnToSettings()
                     })

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/AnilistLoginActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/AnilistLoginActivity.kt
@@ -30,7 +30,7 @@ class AnilistLoginActivity : AppCompatActivity() {
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe({
-                      returnToSettings()
+                        returnToSettings()
                     }, { _ ->
                         returnToSettings()
                     })

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,6 +385,7 @@
     <string name="dropped">Dropped</string>
     <string name="on_hold">On hold</string>
     <string name="plan_to_read">Plan to read</string>
+    <string name="repeating">Re-reading</string>
     <string name="score">Score</string>
     <string name="title">Title</string>
     <string name="status">Status</string>


### PR DESCRIPTION
Switches to using the Anilist v2 API.
Login is now done by implicit grant and tokens are good for one year.
Users will need to login again after token expiration.
"clientId" on line 289 of AnilistApi.kt should be changed to Tachiyomi's
own client ID number.