### PR TITLE
Change AniList search query to show some previously hidden entries.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -91,7 +91,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         val query = """
             query Search(${'$'}query: String) {
                   Page (perPage: 25) {
-                    media(search: ${'$'}query, type: MANGA, format: MANGA) {
+                    media(search: ${'$'}query, type: MANGA, format_not_in: [NOVEL]) {
                       id
                       title {
                         romaji


### PR DESCRIPTION
Addresses issue #1434.

For some reason, AniList API v2 was not returning the correct search results when query arguments `type: MANGA` and `format: MANGA` were both present. Removing `format: MANGA` makes the query return the correct results. Specifically, it returns Korean manhwa as well as Japanese manga, where it was not always returning manhwa before. For instance, Noblesse (manhwa) and One Piece (manga) were both showing fine, but Lookism (manhwa) was not.

I changed the format argument to `format_not_in: [NOVEL]` because there are only three manga related MediaFormats: MANGA, NOVEL, and ONE_SHOT. Filtering out NOVEL entries leaves manga and one-shots, both of which are relevant to Tachiyomi, and which allows all manga and manhwa entries (that I have so far tested) to show in the search results.

Example of Lookism correctly showing in tracking search:
![screenshot_20180527-151350 1](https://user-images.githubusercontent.com/6520686/40590048-4d13da8a-61c6-11e8-9fc9-df28e57aea5b.png)
