### PR TITLE
Update manga.last_update on ChapterSourceSync.syncChaptersWithSource()

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -304,9 +304,6 @@ class LibraryUpdateService(
                 }
                 // Add manga with new chapters to the list.
                 .doOnNext { manga ->
-                    // Set last updated time
-                    manga.last_update = Date().time
-                    db.updateLastUpdated(manga).executeAsBlocking()
                     // Add to the list
                     newUpdates.add(manga)
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterSourceSync.kt
@@ -122,6 +122,10 @@ fun syncChaptersWithSource(db: DatabaseHelper,
 
         // Fix order in source.
         db.fixChaptersSourceOrder(sourceChapters).executeAsBlocking()
+
+        // Set this manga as updated since chapters were changed
+        manga.last_update = Date().time
+        db.updateLastUpdated(manga).executeAsBlocking()
     }
     return Pair(toAdd.subtract(readded).toList(), toDelete.subtract(readded).toList())
 


### PR DESCRIPTION
Update manga.last_update on ChapterSourceSync.syncChaptersWithSource() rather than only during LibraryUpdateService.updateChapterList()

Viewing a manga's info page for the first time forces a chapter sync.
Prior behavior would cause new chapters to be retrieved for that manga, but with manga.last_update remaining at 0 (until a library update occurred in which chapters were added).
New behavior updates last_update any time the chapters are changed via syncChaptersWithSource().