### PR TITLE
Handle manga info fetch errors in the same way as chapter fetch errors

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -355,8 +355,9 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
     /**
      * Update swipe refresh to start showing refresh in progress spinner.
      */
-    fun onFetchMangaError() {
+    fun onFetchMangaError(error: Throwable) {
         setRefreshing(false)
+        activity?.toast(error.message)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoPresenter.kt
@@ -90,9 +90,7 @@ class MangaInfoPresenter(
                 .doOnNext { sendMangaToView() }
                 .subscribeFirst({ view, _ ->
                     view.onFetchMangaDone()
-                }, { view, _ ->
-                    view.onFetchMangaError()
-                })
+                }, MangaInfoController::onFetchMangaError)
     }
 
     /**


### PR DESCRIPTION
(Using a toast)

This is only for MangaInfoController's initial manga view and/or swipe refresh, _not_ for other places that fetch manga info (e.g. catalog view).