### PR TITLE
For migration, put the selected source at the top of the search list instead of excluding it

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchHolder.kt
@@ -45,8 +45,11 @@ class CatalogueSearchHolder(view: View, val adapter: CatalogueSearchAdapter) :
         val source = item.source
         val results = item.results
 
-        // Set Title witch country code if available.
-        title.text = if (!source.lang.isEmpty()) "${source.name} (${source.lang})" else source.name
+        val titlePrefix = if (item.highlighted) "▶" else ""
+        val langSuffix = if (source.lang.isNotEmpty()) " (${source.lang})" else ""
+
+        // Set Title with country code if available.
+        title.text = titlePrefix + source.name + langSuffix
 
         when {
             results == null -> {
@@ -93,5 +96,4 @@ class CatalogueSearchHolder(view: View, val adapter: CatalogueSearchAdapter) :
 
         return null
     }
-
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchItem.kt
@@ -9,9 +9,11 @@ import eu.kanade.tachiyomi.source.CatalogueSource
 /**
  * Item that contains search result information.
  *
- * @param source contains information about search result.
+ * @param source the source for the search results.
+ * @param results the search results.
+ * @param highlighted whether this search item should be highlighted/marked in the catalogue search view.
  */
-class CatalogueSearchItem(val source: CatalogueSource, val results: List<CatalogueSearchCardItem>?)
+class CatalogueSearchItem(val source: CatalogueSource, val results: List<CatalogueSearchCardItem>?, val highlighted: Boolean = false)
     : AbstractFlexibleItem<CatalogueSearchHolder>() {
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchPresenter.kt
@@ -98,7 +98,14 @@ open class CatalogueSearchPresenter(
     }
 
     /**
-     * Initiates a search for mnaga per catalogue.
+     * Creates a catalogue search item
+     */
+    protected open fun createCatalogueSearchItem(source: CatalogueSource, results: List<CatalogueSearchCardItem>?): CatalogueSearchItem {
+        return CatalogueSearchItem(source, results)
+    }
+
+    /**
+     * Initiates a search for manga per catalogue.
      *
      * @param query query on which to search.
      */
@@ -113,7 +120,7 @@ open class CatalogueSearchPresenter(
         initializeFetchImageSubscription()
 
         // Create items with the initial state
-        val initialItems = sources.map { CatalogueSearchItem(it, null) }
+        val initialItems = sources.map { createCatalogueSearchItem(it, null) }
         var items = initialItems
 
         fetchSourcesSubscription?.unsubscribe()
@@ -125,7 +132,7 @@ open class CatalogueSearchPresenter(
                             .map { it.mangas.take(10) } // Get at most 10 manga from search result.
                             .map { it.map { networkToLocalManga(it, source.id) } } // Convert to local manga.
                             .doOnNext { fetchImage(it, source) } // Load manga covers.
-                            .map { CatalogueSearchItem(source, it.map { CatalogueSearchCardItem(it) }) }
+                            .map { createCatalogueSearchItem(source, it.map { CatalogueSearchCardItem(it) }) }
                 }, 5)
                 .observeOn(AndroidSchedulers.mainThread())
                 // Update matching source with the obtained results

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/SearchPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/SearchPresenter.kt
@@ -2,6 +2,8 @@ package eu.kanade.tachiyomi.ui.migration
 
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.source.CatalogueSource
+import eu.kanade.tachiyomi.ui.catalogue.global_search.CatalogueSearchCardItem
+import eu.kanade.tachiyomi.ui.catalogue.global_search.CatalogueSearchItem
 import eu.kanade.tachiyomi.ui.catalogue.global_search.CatalogueSearchPresenter
 
 class SearchPresenter(
@@ -13,5 +15,10 @@ class SearchPresenter(
         // Put the source of the selected manga at the top
         return super.getEnabledSources()
                 .sortedByDescending { it.id == manga.source }
+    }
+
+    override fun createCatalogueSearchItem(source: CatalogueSource, results: List<CatalogueSearchCardItem>?): CatalogueSearchItem {
+        //Set the catalogue search item as highlighted if the source matches that of the selected manga
+        return CatalogueSearchItem(source, results, source.id == manga.source)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/SearchPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/SearchPresenter.kt
@@ -10,8 +10,8 @@ class SearchPresenter(
 ) : CatalogueSearchPresenter(initialQuery) {
 
     override fun getEnabledSources(): List<CatalogueSource> {
-        // Filter out the source of the selected manga
+        // Put the source of the selected manga at the top
         return super.getEnabledSources()
-                .filterNot { it.id == manga.source }
+                .sortedByDescending { it.id == manga.source }
     }
 }


### PR DESCRIPTION
Verified that this does not affect the order of the other elements.

I've also verified that both copy and migrate work for same-source migration, even if you select the manga you've already got selected.