### PR TITLE
Set notification number for library updates to number of new updates

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -460,6 +460,7 @@ class LibraryUpdateService(
             if (newUpdates.size > 1) {
                 setContentText(getString(R.string.notification_new_chapters_text, newUpdates.size))
                 setStyle(NotificationCompat.BigTextStyle().bigText(newUpdates.joinToString("\n")))
+                setNumber(newUpdates.size)
             } else {
                 setContentText(newUpdates.first())
             }


### PR DESCRIPTION
On systems that support badging, this makes the app icon's badge show the count of updates rather than just (1).