### PR TITLE
AniList 5-star/smiley <-> 100-point values differ from the AniList website

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -95,9 +95,15 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
             // 100 point
             POINT_100 -> index.toFloat()
             // 5 stars
-            POINT_5 -> index * 20f
+            POINT_5 -> when {
+                index == 0 -> 0f
+                else -> index * 20f - 10f
+            }
             // Smiley
-            POINT_3 -> index * 30f
+            POINT_3 -> when {
+                index == 0 -> 0f
+                else -> index * 25f + 10f
+            }
             // 10 point decimal
             POINT_10_DECIMAL -> index.toFloat()
             else -> throw Exception("Unknown score type")
@@ -108,10 +114,13 @@ class Anilist(private val context: Context, id: Int) : TrackService(id) {
         val score = track.score
 
         return when (scorePreference.getOrDefault()) {
-            POINT_5 -> "${(score / 20).toInt()} ★"
+            POINT_5 -> when {
+                score == 0f -> "0 ★"
+                else -> "${((score + 10) / 20).toInt()} ★"
+            }
             POINT_3 -> when {
                 score == 0f -> "0"
-                score <= 30 -> "😦"
+                score <= 35 -> "😦"
                 score <= 60 -> "😐"
                 else -> "😊"
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistModels.kt
@@ -97,7 +97,7 @@ fun Track.toAnilistScore(): String = when (preferences.anilistScoreType().getOrD
 // Smiley
     "POINT_3" -> when {
         score == 0f -> "0"
-        score <= 30 -> ":("
+        score <= 35 -> ":("
         score <= 60 -> ":|"
         else -> ":)"
     }


### PR DESCRIPTION
**App version:**
0.7.4

**Issue/Request:**
When using AniList with the 5-star rating mode, the website's raw ratings go 0, 10, 30, 50, 70, 90, while Tachiyomi's go 0, 20, 40, 60, 80, 100.

This results in ratings made on the website showing up as 1 star lower within the app due to the integer conversion, and ratings made within the app making website stats less clean:
![image](https://user-images.githubusercontent.com/1596835/46047971-2b40fd00-c0f5-11e8-943f-da1d1bc7e835.png)
(AniList's stats page still shows 100-point ratings in 5-star mode)

I checked the smiley scale as well, which goes 0, 35, 60, 85 vs. 0, 30, 60, 90 in the app.
