### PR TITLE
 Update mangasee URL 

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangasee.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Mangasee.kt
@@ -18,7 +18,7 @@ class Mangasee : ParsedHttpSource() {
 
     override val name = "Mangasee"
 
-    override val baseUrl = "http://mangaseeonline.net"
+    override val baseUrl = "http://mangaseeonline.us"
 
     override val lang = "en"
 


### PR DESCRIPTION
The old URL http://mangaseeonline.net is obsolete, the new URL is http://mangaseeonline.us