### PR TITLE
Update Anilist API search to return 50 results

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -90,7 +90,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
     fun search(search: String): Observable<List<TrackSearch>> {
         val query = """
             query Search(${'$'}query: String) {
-                  Page (perPage: 25) {
+                  Page (perPage: 50) {
                     media(search: ${'$'}query, type: MANGA, format_not_in: [NOVEL]) {
                       id
                       title {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -102,6 +102,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                       type
                       status
                       chapters
+                      description
                       startDate {
                         year
                         month
@@ -160,6 +161,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                       type
                       status
                       chapters
+                      description
                       startDate {
                        year
                        month
@@ -245,7 +247,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
 
     fun jsonToALManga(struct: JsonObject): ALManga{
         return ALManga(struct["id"].asInt, struct["title"]["romaji"].asString, struct["coverImage"]["large"].asString,
-                null, struct["type"].asString, struct["status"].asString,
+                struct["description"].nullString.orEmpty(), struct["type"].asString, struct["status"].asString,
                 struct["startDate"]["year"].nullString.orEmpty() + struct["startDate"]["month"].nullString.orEmpty()
                         + struct["startDate"]["day"].nullString.orEmpty(), struct["chapters"].nullInt ?: 0)
     }


### PR DESCRIPTION
This will help alleviate not being able to find manga with generic names
such as Monster.

This also adds the mission description to the Anilist search dialogue.