### PR TITLE
Handle empty manga thumbnail_urls in the cover cache

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/CoverCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/CoverCache.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.data.cache
 
 import android.content.Context
+import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.util.DiskUtil
 import java.io.File
 import java.io.IOException
@@ -26,24 +27,25 @@ class CoverCache(private val context: Context) {
     /**
      * Returns the cover from cache.
      *
-     * @param thumbnailUrl the thumbnail url.
+     * @param manga the manga to get cover of.
      * @return cover image.
      */
-    fun getCoverFile(thumbnailUrl: String): File {
+    fun getCoverFile(manga: Manga): File {
+        val thumbnailUrl = manga.thumbnail_url ?: manga.url
         return File(cacheDir, DiskUtil.hashKeyForDisk(thumbnailUrl))
     }
 
     /**
      * Copy the given stream to this cache.
      *
-     * @param thumbnailUrl url of the thumbnail.
+     * @param manga the manga to change cover of.
      * @param inputStream  the stream to copy.
      * @throws IOException if there's any error.
      */
     @Throws(IOException::class)
-    fun copyToCache(thumbnailUrl: String, inputStream: InputStream) {
+    fun copyToCache(manga: Manga, inputStream: InputStream) {
         // Get destination file.
-        val destFile = getCoverFile(thumbnailUrl)
+        val destFile = getCoverFile(manga)
 
         destFile.outputStream().use { inputStream.copyTo(it) }
     }
@@ -51,16 +53,12 @@ class CoverCache(private val context: Context) {
     /**
      * Delete the cover file from the cache.
      *
-     * @param thumbnailUrl the thumbnail url.
+     * @param manga the manga to remove cover of.
      * @return status of deletion.
      */
-    fun deleteFromCache(thumbnailUrl: String?): Boolean {
-        // Check if url is empty.
-        if (thumbnailUrl.isNullOrEmpty())
-            return false
-
+    fun deleteFromCache(manga: Manga): Boolean {
         // Remove file.
-        val file = getCoverFile(thumbnailUrl!!)
+        val file = getCoverFile(manga)
         return file.exists() && file.delete()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/CoverCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/CoverCache.kt
@@ -31,7 +31,9 @@ class CoverCache(private val context: Context) {
      * @return cover image.
      */
     fun getCoverFile(manga: Manga): File {
-        val thumbnailUrl = manga.thumbnail_url ?: manga.url
+        val backup = "${manga.source}${manga.url}"
+        var thumbnailUrl = manga.thumbnail_url ?: backup
+        if (thumbnailUrl.isEmpty()) thumbnailUrl = backup
         return File(cacheDir, DiskUtil.hashKeyForDisk(thumbnailUrl))
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaModelLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaModelLoader.kt
@@ -7,7 +7,6 @@ import com.bumptech.glide.load.model.*
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.network.NetworkHelper
-import eu.kanade.tachiyomi.source.LocalSource
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.online.HttpSource
 import uy.kohesive.injekt.Injekt
@@ -102,9 +101,10 @@ class MangaModelLoader : ModelLoader<Manga, InputStream> {
             return ModelLoader.LoadData(MangaSignature(manga, file), libraryFetcher)
         } else {
             // Get the file from the url, removing the scheme if present, or from the cache if no url.
-            val file = url?.run {
-                File(url.substringAfter("file://"))
-            } ?: coverCache.getCoverFile(manga)
+            val file = if (url != null) File(url.substringAfter("file://"))
+                    else coverCache.getCoverFile(manga)
+
+            if (!file.exists()) return null;
 
             // Return an instance of the fetcher providing the needed elements.
             return ModelLoader.LoadData(MangaSignature(manga, file), FileFetcher(file))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaModelLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaModelLoader.kt
@@ -101,7 +101,7 @@ class MangaModelLoader : ModelLoader<Manga, InputStream> {
             return ModelLoader.LoadData(MangaSignature(manga, file), libraryFetcher)
         } else {
             // Get the file from the url, removing the scheme if present, or from the cache if no url.
-            val file = if (url != null) File(url.substringAfter("file://"))
+            val file = if (url != null && url.startsWith("file")) File(url.substringAfter("file://"))
                     else coverCache.getCoverFile(manga)
 
             if (!file.exists()) return null;

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCataloguePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCataloguePresenter.kt
@@ -254,7 +254,7 @@ open class BrowseCataloguePresenter(
     fun changeMangaFavorite(manga: Manga) {
         manga.favorite = !manga.favorite
         if (!manga.favorite) {
-            coverCache.deleteFromCache(manga.thumbnail_url)
+            coverCache.deleteFromCache(manga)
         }
         db.insertManga(manga).executeAsBlocking()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/CatalogueGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/CatalogueGridHolder.kt
@@ -37,13 +37,11 @@ class CatalogueGridHolder(private val view: View, private val adapter: FlexibleA
 
     override fun setImage(manga: Manga) {
         GlideApp.with(view.context).clear(thumbnail)
-        if (!manga.thumbnail_url.isNullOrEmpty()) {
-            GlideApp.with(view.context)
+        GlideApp.with(view.context)
                     .load(manga)
                     .diskCacheStrategy(DiskCacheStrategy.DATA)
                     .centerCrop()
                     .placeholder(android.R.color.transparent)
                     .into(StateImageViewTarget(thumbnail, progress))
-        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/CatalogueListHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/CatalogueListHolder.kt
@@ -37,8 +37,7 @@ class CatalogueListHolder(private val view: View, adapter: FlexibleAdapter<*>) :
 
     override fun setImage(manga: Manga) {
         GlideApp.with(view.context).clear(thumbnail)
-        if (!manga.thumbnail_url.isNullOrEmpty()) {
-            GlideApp.with(view.context)
+        GlideApp.with(view.context)
                     .load(manga)
                     .diskCacheStrategy(DiskCacheStrategy.DATA)
                     .centerCrop()
@@ -46,7 +45,6 @@ class CatalogueListHolder(private val view: View, adapter: FlexibleAdapter<*>) :
                     .dontAnimate()
                     .placeholder(android.R.color.transparent)
                     .into(thumbnail)
-        }
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchCardHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchCardHolder.kt
@@ -38,15 +38,13 @@ class CatalogueSearchCardHolder(view: View, adapter: CatalogueSearchCardAdapter)
 
     fun setImage(manga: Manga) {
         GlideApp.with(itemView.context).clear(itemImage)
-        if (!manga.thumbnail_url.isNullOrEmpty()) {
-            GlideApp.with(itemView.context)
+        GlideApp.with(itemView.context)
                     .load(manga)
                     .diskCacheStrategy(DiskCacheStrategy.DATA)
                     .centerCrop()
                     .skipMemoryCache(true)
                     .placeholder(android.R.color.transparent)
                     .into(StateImageViewTarget(itemImage, progress))
-        }
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -361,7 +361,7 @@ class LibraryPresenter(
             return true
         }
 
-        if (manga.thumbnail_url != null && manga.favorite) {
+        if (manga.favorite) {
             coverCache.copyToCache(manga, inputStream)
             return true
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -316,7 +316,7 @@ class LibraryPresenter(
 
         Observable.fromCallable {
             mangaToDelete.forEach { manga ->
-                coverCache.deleteFromCache(manga.thumbnail_url)
+                coverCache.deleteFromCache(manga)
                 if (deleteChapters) {
                     val source = sourceManager.get(manga.source) as? HttpSource
                     if (source != null) {
@@ -362,7 +362,7 @@ class LibraryPresenter(
         }
 
         if (manga.thumbnail_url != null && manga.favorite) {
-            coverCache.copyToCache(manga.thumbnail_url!!, inputStream)
+            coverCache.copyToCache(manga, inputStream)
             return true
         }
         return false

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -225,7 +225,7 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
         setFavoriteDrawable(manga.favorite)
 
         // Set cover if it wasn't already.
-        if (manga_cover.drawable == null && !manga.thumbnail_url.isNullOrEmpty()) {
+        if (manga_cover.drawable == null) {
             GlideApp.with(view.context)
                     .load(manga)
                     .diskCacheStrategy(DiskCacheStrategy.RESOURCE)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoPresenter.kt
@@ -101,7 +101,7 @@ class MangaInfoPresenter(
     fun toggleFavorite(): Boolean {
         manga.favorite = !manga.favorite
         if (!manga.favorite) {
-            coverCache.deleteFromCache(manga.thumbnail_url)
+            coverCache.deleteFromCache(manga)
         }
         db.insertManga(manga).executeAsBlocking()
         sendMangaToView()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -518,9 +518,8 @@ class ReaderPresenter(
                         R.string.cover_updated
                         SetAsCoverResult.Success
                     } else {
-                        val thumbUrl = manga.thumbnail_url ?: throw Exception("Image url not found")
                         if (manga.favorite) {
-                            coverCache.copyToCache(thumbUrl, stream())
+                            coverCache.copyToCache(manga, stream())
                             SetAsCoverResult.Success
                         } else {
                             SetAsCoverResult.AddToLibraryFirst

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent_updates/RecentChapterHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent_updates/RecentChapterHolder.kt
@@ -68,13 +68,11 @@ class RecentChapterHolder(private val view: View, private val adapter: RecentCha
 
         // Set cover
         GlideApp.with(itemView.context).clear(manga_cover)
-        if (!item.manga.thumbnail_url.isNullOrEmpty()) {
-            GlideApp.with(itemView.context)
+        GlideApp.with(itemView.context)
                     .load(item.manga)
                     .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                     .circleCrop()
                     .into(manga_cover)
-        }
 
         // Check if chapter is read and set correct color
         if (item.chapter.read) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recently_read/RecentlyReadHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recently_read/RecentlyReadHolder.kt
@@ -59,13 +59,11 @@ class RecentlyReadHolder(
 
         // Set cover
         GlideApp.with(itemView.context).clear(cover)
-        if (!manga.thumbnail_url.isNullOrEmpty()) {
-            GlideApp.with(itemView.context)
+        GlideApp.with(itemView.context)
                     .load(manga)
                     .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                     .centerCrop()
                     .into(cover)
-        }
     }
 
 


### PR DESCRIPTION
Fixes #1663 

Uses the source and manga's url as a unique value for hashing.

Example of it wirking with the JapScan source, which has no thumbnails: ![screenshot_1539830104](https://user-images.githubusercontent.com/9275775/47128395-dac94500-d245-11e8-8650-4a99f5093c58.png)

~~This does cause FileNotFound exceptions in FileFetcher when there is no cover set, though.~~