### PR TITLE
Force Migration to display titles from source rather than from local DB

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
@@ -82,6 +82,11 @@ interface MangaQueries : DbProvider {
             .withPutResolver(MangaViewerPutResolver())
             .prepare()
 
+    fun updateMangaTitle(manga: Manga) = db.put()
+            .`object`(manga)
+            .withPutResolver(MangaTitlePutResolver())
+            .prepare()
+
     fun deleteManga(manga: Manga) = db.delete().`object`(manga).prepare()
 
     fun deleteMangas(mangas: List<Manga>) = db.delete().objects(mangas).prepare()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/resolvers/MangaTitlePutResolver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/resolvers/MangaTitlePutResolver.kt
@@ -9,7 +9,7 @@ import eu.kanade.tachiyomi.data.database.inTransactionReturn
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.tables.MangaTable
 
-class MangaViewerPutResolver : PutResolver<Manga>() {
+class MangaTitlePutResolver : PutResolver<Manga>() {
 
     override fun performPut(db: StorIOSQLite, manga: Manga) = db.inTransactionReturn {
         val updateQuery = mapToUpdateQuery(manga)
@@ -26,7 +26,7 @@ class MangaViewerPutResolver : PutResolver<Manga>() {
             .build()
 
     fun mapToContentValues(manga: Manga) = ContentValues(1).apply {
-        put(MangaTable.COL_VIEWER, manga.viewer)
+        put(MangaTable.COL_TITLE, manga.title)
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchPresenter.kt
@@ -208,7 +208,7 @@ open class CatalogueSearchPresenter(
      * @param sManga the manga from the source.
      * @return a manga from the database.
      */
-    private fun networkToLocalManga(sManga: SManga, sourceId: Long): Manga {
+    protected open fun networkToLocalManga(sManga: SManga, sourceId: Long): Manga {
         var localManga = db.getManga(sManga.url, sourceId).executeAsBlocking()
         if (localManga == null) {
             val newManga = Manga.create(sManga.url, sManga.title, sourceId)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/MigrationPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/MigrationPresenter.kt
@@ -146,6 +146,9 @@ class MigrationPresenter(
             }
             manga.favorite = true
             db.updateMangaFavorite(manga).executeAsBlocking()
+
+            // SearchPresenter#networkToLocalManga may have updated the manga title, so ensure db gets updated title
+            db.updateMangaTitle(manga).executeAsBlocking()
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/SearchPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/SearchPresenter.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.ui.migration
 
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.source.CatalogueSource
+import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.ui.catalogue.global_search.CatalogueSearchCardItem
 import eu.kanade.tachiyomi.ui.catalogue.global_search.CatalogueSearchItem
 import eu.kanade.tachiyomi.ui.catalogue.global_search.CatalogueSearchPresenter
@@ -20,5 +21,12 @@ class SearchPresenter(
     override fun createCatalogueSearchItem(source: CatalogueSource, results: List<CatalogueSearchCardItem>?): CatalogueSearchItem {
         //Set the catalogue search item as highlighted if the source matches that of the selected manga
         return CatalogueSearchItem(source, results, source.id == manga.source)
+    }
+
+    override fun networkToLocalManga(sManga: SManga, sourceId: Long): Manga {
+        val localManga = super.networkToLocalManga(sManga, sourceId)
+        // For migration, displayed title should always match source rather than local DB
+        localManga.title = sManga.title
+        return localManga
     }
 }


### PR DESCRIPTION
...and update local titles when migration occurs

Background: if a user, for whatever reason, gets an old/incorrect title for a manga, and that title is later corrected by the source (with the same URL), the user cannot update the local DB title until they unfollow the manga, clear the DB of unfollowed manga, and refollow the manga.

However, the potential solution of forcing titles to update on manga info update leads to the possible confusing situation where a manga's title randomly changes (from the end user's perspective).

Thus, this makes the act of changing a manga's title explicit (in that it's a part of migration flow), and makes migration trust the source rather than the local DB for manga titles.