### PR TITLE
1.x - add DateAdded to Manga

### DIFF
--- a/domain/src/main/kotlin/manga/model/Manga.kt
+++ b/domain/src/main/kotlin/manga/model/Manga.kt
@@ -15,6 +15,7 @@ data class Manga(
   val cover: String = "",
   val favorite: Boolean = false,
   val lastUpdate: Long = 0,
+  val dateAdded: Long = 0,
   val initialized: Boolean = false,
   val viewer: Int = 0,
   val flags: Int = 0


### PR DESCRIPTION
add dateAdded field.  This will allow future library view to sort by added date.

Should this be lateint?  to make setting it mandatory?  Or does the interactor ChangeMangaFavorite need to create a new manga object with the date when added to library.  