### PR TITLE
Fixed Gradle script bug on newer Android Studio versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'com.github.ben-manes.versions'
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.0'
@@ -18,8 +18,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
         maven { url "https://jitpack.io" }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }


### PR DESCRIPTION
Apparently the repository order may cause bugs for new projects on newer Android Studio versions:
https://stackoverflow.com/questions/51195242/failed-to-resolve-firebase-iid-interop