### PR TITLE
Fix Amoled navigation bar colour

### DIFF
--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -37,7 +37,7 @@
         <!-- Attributes specific for SDK 21 and up  -->
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@color/colorAmoledPrimary</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
     <!--==============-->


### PR DESCRIPTION
This keeps the navigation bar pure-black regardless of OEM modifications.

<details><summary>Nexus 5X</summary>

![image](https://user-images.githubusercontent.com/3440094/49484839-5b60f680-f830-11e8-9e54-0ff450c2146f.png)
</details>

<details><summary>OnePlus 6T</summary>

![screenshot_20181205-015252](https://user-images.githubusercontent.com/3440094/49484906-aed34480-f830-11e8-9b8f-63df033d9fd6.jpg)
</details>
