### PR TITLE
Update ranking

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateRanker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateRanker.kt
@@ -1,0 +1,41 @@
+package eu.kanade.tachiyomi.data.library
+
+import java.util.Comparator
+
+import eu.kanade.tachiyomi.data.database.models.Manga
+
+/**
+ * This class will provide various functions to Rank mangas to efficiently schedule mangas to update.
+ */
+internal class LibraryUpdateRanker {
+    companion object {
+        /**
+         * Provides a total ordering over all the Mangas.
+         *
+         * Assumption: An active [Manga] mActive is expected to have been last updated after an
+         * inactive [Manga] mInactive.
+         *
+         * Using this insight, function returns a Comparator for which mActive appears before mInactive.
+         * @return a Comparator that ranks manga based on relevance.
+         */
+        fun relevanceRanking(): Comparator<Manga> {
+            return Comparator { mangaFirst: Manga,
+                                mangaSecond: Manga ->
+                compareValues(mangaSecond.last_update, mangaFirst.last_update)
+            }
+        }
+
+        /**
+         * Provides a total ordering over all the Mangas.
+         *
+         * Order the manga lexicographically.
+         * @return a Comparator that ranks manga lexicographically based on the title.
+         */
+        fun lexicographicRanking(): Comparator<Manga> {
+            return kotlin.Comparator { mangaFirst: Manga,
+                                       mangaSecond: Manga ->
+                compareValues(mangaFirst.title, mangaSecond.title)
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateRanker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateRanker.kt
@@ -9,6 +9,9 @@ import eu.kanade.tachiyomi.data.database.models.Manga
  */
 internal class LibraryUpdateRanker {
     companion object {
+        val rankingScheme = listOf(
+                (this::lexicographicRanking)(),
+                (this::relevanceRanking)())
         /**
          * Provides a total ordering over all the Mangas.
          *

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateRanker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateRanker.kt
@@ -1,44 +1,43 @@
 package eu.kanade.tachiyomi.data.library
 
-import java.util.Comparator
-
 import eu.kanade.tachiyomi.data.database.models.Manga
 
 /**
  * This class will provide various functions to Rank mangas to efficiently schedule mangas to update.
  */
-internal class LibraryUpdateRanker {
-    companion object {
-        val rankingScheme = listOf(
-                (this::lexicographicRanking)(),
-                (this::latestFirstRanking)())
-        /**
-         * Provides a total ordering over all the Mangas.
-         *
-         * Assumption: An active [Manga] mActive is expected to have been last updated after an
-         * inactive [Manga] mInactive.
-         *
-         * Using this insight, function returns a Comparator for which mActive appears before mInactive.
-         * @return a Comparator that ranks manga based on relevance.
-         */
-        fun latestFirstRanking(): Comparator<Manga> {
-            return Comparator { mangaFirst: Manga,
-                                mangaSecond: Manga ->
-                compareValues(mangaSecond.last_update, mangaFirst.last_update)
-            }
-        }
+object LibraryUpdateRanker {
 
-        /**
-         * Provides a total ordering over all the Mangas.
-         *
-         * Order the manga lexicographically.
-         * @return a Comparator that ranks manga lexicographically based on the title.
-         */
-        fun lexicographicRanking(): Comparator<Manga> {
-            return kotlin.Comparator { mangaFirst: Manga,
-                                       mangaSecond: Manga ->
-                compareValues(mangaFirst.title, mangaSecond.title)
-            }
+    val rankingScheme = listOf(
+            (this::lexicographicRanking)(),
+            (this::latestFirstRanking)())
+
+    /**
+     * Provides a total ordering over all the Mangas.
+     *
+     * Assumption: An active [Manga] mActive is expected to have been last updated after an
+     * inactive [Manga] mInactive.
+     *
+     * Using this insight, function returns a Comparator for which mActive appears before mInactive.
+     * @return a Comparator that ranks manga based on relevance.
+     */
+    fun latestFirstRanking(): Comparator<Manga> {
+        return Comparator { mangaFirst: Manga,
+                            mangaSecond: Manga ->
+            compareValues(mangaSecond.last_update, mangaFirst.last_update)
         }
     }
+
+    /**
+     * Provides a total ordering over all the Mangas.
+     *
+     * Order the manga lexicographically.
+     * @return a Comparator that ranks manga lexicographically based on the title.
+     */
+    fun lexicographicRanking(): Comparator<Manga> {
+        return Comparator { mangaFirst: Manga,
+                                   mangaSecond: Manga ->
+            compareValues(mangaFirst.title, mangaSecond.title)
+        }
+    }
+
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateRanker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateRanker.kt
@@ -11,7 +11,7 @@ internal class LibraryUpdateRanker {
     companion object {
         val rankingScheme = listOf(
                 (this::lexicographicRanking)(),
-                (this::relevanceRanking)())
+                (this::latestFirstRanking)())
         /**
          * Provides a total ordering over all the Mangas.
          *
@@ -21,7 +21,7 @@ internal class LibraryUpdateRanker {
          * Using this insight, function returns a Comparator for which mActive appears before mInactive.
          * @return a Comparator that ranks manga based on relevance.
          */
-        fun relevanceRanking(): Comparator<Manga> {
+        fun latestFirstRanking(): Comparator<Manga> {
             return Comparator { mangaFirst: Manga,
                                 mangaSecond: Manga ->
                 compareValues(mangaSecond.last_update, mangaFirst.last_update)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadService
 import eu.kanade.tachiyomi.data.library.LibraryUpdateService.Companion.start
+import eu.kanade.tachiyomi.data.library.LibraryUpdateRanker.Companion.relevanceRanking
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
@@ -205,6 +206,7 @@ class LibraryUpdateService(
         subscription = Observable
                 .defer {
                     val mangaList = getMangaToUpdate(intent, target)
+                            .sortedWith(relevanceRanking())
 
                     // Update either chapter list or manga details.
                     when (target) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -18,7 +18,7 @@ import eu.kanade.tachiyomi.data.database.models.LibraryManga
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadService
-import eu.kanade.tachiyomi.data.library.LibraryUpdateRanker.Companion.rankingScheme
+import eu.kanade.tachiyomi.data.library.LibraryUpdateRanker.rankingScheme
 import eu.kanade.tachiyomi.data.library.LibraryUpdateService.Companion.start
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
@@ -205,10 +205,9 @@ class LibraryUpdateService(
         // Update favorite manga. Destroy service when completed or in case of an error.
         subscription = Observable
                 .defer {
+                    val selectedScheme = preferences.libraryUpdatePrioritization().getOrDefault()
                     val mangaList = getMangaToUpdate(intent, target)
-                            .sortedWith(
-                                    rankingScheme[preferences.libraryUpdatePrioritization().getOrDefault()]
-                            )
+                            .sortedWith(rankingScheme[selectedScheme])
 
                     // Update either chapter list or manga details.
                     when (target) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -18,8 +18,8 @@ import eu.kanade.tachiyomi.data.database.models.LibraryManga
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadService
+import eu.kanade.tachiyomi.data.library.LibraryUpdateRanker.Companion.rankingScheme
 import eu.kanade.tachiyomi.data.library.LibraryUpdateService.Companion.start
-import eu.kanade.tachiyomi.data.library.LibraryUpdateRanker.Companion.relevanceRanking
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
@@ -206,7 +206,9 @@ class LibraryUpdateService(
         subscription = Observable
                 .defer {
                     val mangaList = getMangaToUpdate(intent, target)
-                            .sortedWith(relevanceRanking())
+                            .sortedWith(
+                                    rankingScheme[preferences.libraryUpdatePrioritization().getOrDefault()]
+                            )
 
                     // Update either chapter list or manga details.
                     when (target) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -81,6 +81,8 @@ object PreferenceKeys {
 
     const val libraryUpdateCategories = "library_update_categories"
 
+    const val libraryUpdatePrioritization = "library_update_prioritization"
+
     const val filterDownloaded = "pref_filter_downloaded_key"
 
     const val filterUnread = "pref_filter_unread_key"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -9,7 +9,6 @@ import com.f2prateek.rx.preferences.RxSharedPreferences
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.track.TrackService
 import eu.kanade.tachiyomi.source.Source
-import kotlinx.coroutines.experimental.channels.NULL_VALUE
 import java.io.File
 import eu.kanade.tachiyomi.data.preference.PreferenceKeys as Keys
 
@@ -138,7 +137,7 @@ class PreferencesHelper(val context: Context) {
 
     fun libraryUpdateCategories() = rxPrefs.getStringSet(Keys.libraryUpdateCategories, emptySet())
 
-    fun libraryUpdatePrioritization() = rxPrefs.getInteger(Keys.libraryUpdatePrioritization, 0)
+    fun libraryUpdatePrioritization() = rxPrefs.getInteger(Keys.libraryUpdatePrioritization, 1)
 
     fun libraryAsList() = rxPrefs.getBoolean(Keys.libraryAsList, false)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -9,6 +9,7 @@ import com.f2prateek.rx.preferences.RxSharedPreferences
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.track.TrackService
 import eu.kanade.tachiyomi.source.Source
+import kotlinx.coroutines.experimental.channels.NULL_VALUE
 import java.io.File
 import eu.kanade.tachiyomi.data.preference.PreferenceKeys as Keys
 
@@ -136,6 +137,8 @@ class PreferencesHelper(val context: Context) {
     fun libraryUpdateRestriction() = prefs.getStringSet(Keys.libraryUpdateRestriction, emptySet())
 
     fun libraryUpdateCategories() = rxPrefs.getStringSet(Keys.libraryUpdateCategories, emptySet())
+
+    fun libraryUpdatePrioritization() = rxPrefs.getInteger(Keys.libraryUpdatePrioritization, 0)
 
     fun libraryAsList() = rxPrefs.getBoolean(Keys.libraryAsList, false)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
@@ -165,8 +165,8 @@ class SettingsGeneralController : SettingsController() {
             // The following arrays are to be lined up with the list rankingScheme in:
             // ../../data/library/LibraryUpdateRanker.kt
             entriesRes = arrayOf(
-                    R.string.lexicographic,
-                    R.string.latest_first
+                    R.string.action_sort_alpha,
+                    R.string.action_sort_last_updated
             )
             entryValues = arrayOf(
                     "0",

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
@@ -172,7 +172,7 @@ class SettingsGeneralController : SettingsController() {
                     "0",
                     "1"
             )
-            defaultValue = "0"
+            defaultValue = "1"
             summaryRes = R.string.pref_library_update_prioritization_summary
         }
         intListPreference {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
@@ -159,6 +159,22 @@ class SettingsGeneralController : SettingsController() {
                             selectedCategories.joinToString { it.name }
                     }
         }
+        intListPreference{
+            key = Keys.libraryUpdatePrioritization
+            titleRes = R.string.pref_library_update_prioritization
+            // The following arrays are to be lined up with the list rankingScheme in:
+            // ../../data/library/LibraryUpdateRanker.kt
+            entriesRes = arrayOf(
+                    R.string.lexicographic,
+                    R.string.latest_first
+            )
+            entryValues = arrayOf(
+                    "0",
+                    "1"
+            )
+            defaultValue = "0"
+            summaryRes = R.string.pref_library_update_prioritization_summary
+        }
         intListPreference {
             key = Keys.defaultCategory
             titleRes = R.string.default_category

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,10 +129,8 @@
     <string name="update_monthly">Monthly</string>
     <string name="pref_library_update_categories">Categories to include in global update</string>
     <string name="all">All</string>
-    <string name="pref_library_update_prioritization">Prioritize library updates</string>
+    <string name="pref_library_update_prioritization">Library update order</string>
     <string name="pref_library_update_prioritization_summary">Select the order in which Tachiyomi checks for update</string>
-    <string name="lexicographic">A-Z</string>
-    <string name="latest_first">Latest First</string>
     <string name="pref_library_update_restriction">Library update restrictions</string>
     <string name="pref_library_update_restriction_summary">Update only when the conditions are met</string>
     <string name="wifi">Wi-Fi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,6 +129,10 @@
     <string name="update_monthly">Monthly</string>
     <string name="pref_library_update_categories">Categories to include in global update</string>
     <string name="all">All</string>
+    <string name="pref_library_update_prioritization">Prioritize library updates</string>
+    <string name="pref_library_update_prioritization_summary">Select the order in which Tachiyomi checks for update</string>
+    <string name="lexicographic">A-Z</string>
+    <string name="latest_first">Latest First</string>
     <string name="pref_library_update_restriction">Library update restrictions</string>
     <string name="pref_library_update_restriction_summary">Update only when the conditions are met</string>
     <string name="wifi">Wi-Fi</string>


### PR DESCRIPTION
The app checked for updates in lexicographic order of title names. This is fine when the update list is small but, as soon as the list becomes long, series later in the lexicographic order say (Zannen Jokanbu Black General-san) starting with the letter 'Z' takes a lot of time as the previous implementation has to go through hundreds of other manga that don't even get updates that frequently/are completed before it can get to 'Z'.

This pull request adds a heuristic to decide the update order of the manga to update active series before checking updates to inactive ones. Furthermore, it provides an easy way to, in the future use more complicated heuristics.