### PR TITLE
Add brightness change by swiping the left edge.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -23,6 +23,8 @@ object PreferenceKeys {
 
     const val customBrightnessValue = "custom_brightness_value"
 
+    const val customBrightnessBySwiping = "custom_brightness_by_swiping"
+
     const val colorFilter = "pref_color_filter_key"
 
     const val colorFilterValue = "color_filter_value"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -51,6 +51,8 @@ class PreferencesHelper(val context: Context) {
 
     fun customBrightnessValue() = rxPrefs.getInteger(Keys.customBrightnessValue, 0)
 
+    fun customBrightnessBySwiping() = rxPrefs.getBoolean(Keys.customBrightnessBySwiping, false)
+
     fun colorFilter() = rxPrefs.getBoolean(Keys.colorFilter, false)
 
     fun colorFilterValue() = rxPrefs.getInteger(Keys.colorFilterValue, 0)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderColorFilterSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderColorFilterSheet.kt
@@ -82,6 +82,17 @@ class ReaderColorFilterSheet(activity: ReaderActivity) : BottomSheetDialog(activ
         custom_brightness.isChecked = preferences.customBrightness().getOrDefault()
         custom_brightness.setOnCheckedChangeListener { _, isChecked ->
             preferences.customBrightness().set(isChecked)
+
+            //it doesn't make sense to change brightness by swiping if custom brightness isn't enabled
+            custom_brightness_swipe_control.isEnabled = isChecked
+            if(!isChecked) preferences.customBrightnessBySwiping().set(false)
+        }
+
+        //it doesn't make sense to change brightness by swiping if custom brightness isn't enabled
+        custom_brightness_swipe_control.isEnabled = preferences.customBrightness().getOrDefault()
+        custom_brightness_swipe_control.isChecked = preferences.customBrightnessBySwiping().getOrDefault()
+        custom_brightness_swipe_control.setOnCheckedChangeListener { _, isChecked ->
+            preferences.customBrightnessBySwiping().set(isChecked)
         }
 
         seekbar_color_filter_alpha.setOnSeekBarChangeListener(object : SimpleSeekBarListener() {

--- a/app/src/main/res/layout/reader_activity.xml
+++ b/app/src/main/res/layout/reader_activity.xml
@@ -117,4 +117,9 @@
         android:layout_height="match_parent"
         android:visibility="gone"/>
 
+    <View
+        android:id="@+id/brightness_swipe_control_view"
+        android:layout_width="15dp"
+        android:layout_height="match_parent"/>
+
 </FrameLayout>

--- a/app/src/main/res/layout/reader_color_filter.xml
+++ b/app/src/main/res/layout/reader_color_filter.xml
@@ -202,4 +202,15 @@
         app:layout_constraintBottom_toBottomOf="@id/brightness_seekbar"
         app:layout_constraintRight_toRightOf="parent"/>
 
+    <!--- Brightness touch control-->
+
+    <android.support.v7.widget.SwitchCompat
+            android:id="@+id/custom_brightness_swipe_control"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:checked="false"
+            android:layout_marginTop="16dp"
+            android:text="@string/pref_custom_brightness_swipe_control"
+            app:layout_constraintTop_toBottomOf="@id/txt_brightness_seekbar_value"/>
+
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,6 +175,7 @@
     <string name="pref_crop_borders">Crop borders</string>
     <string name="pref_custom_brightness">Use custom brightness</string>
     <string name="pref_custom_color_filter">Use custom color filter</string>
+    <string name="pref_custom_brightness_swipe_control">Adjust brightness by swiping the left edge</string>
     <string name="pref_keep_screen_on">Keep screen on</string>
     <string name="pref_reader_navigation">Navigation</string>
     <string name="pref_read_with_volume_keys">Volume keys</string>


### PR DESCRIPTION
This is related to issue https://github.com/inorichi/tachiyomi/issues/1720
Added brightness change by swiping the left edge in reader activity.
Added enable/disable switch in reader_color_filter.xml

The brightness controls work on the bar on the left.

![image](https://user-images.githubusercontent.com/7299384/50457390-67d1fe00-095b-11e9-94e9-e0806484a2c0.png)

This is how the color filter sheet looks now. The added switch is disabled when custom brightness is disabled. I'm not sure if I should mix their code like I did.

![image](https://user-images.githubusercontent.com/7299384/50457423-aa93d600-095b-11e9-8d92-e0f48b01a7a4.png)

I'm sorry for the PreferenceKeys file. I don't why it's marked as if I deleted everything and added it again.
I'm not sure what to do with the translations. I only added the english version.