### PR TITLE
Enable gradle parallel build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true


### PR DESCRIPTION
Since the app is made with a lot of decoupled modules, it probably makes sense to enable gradle parallel mode to improve build speed.

Before:
![non-parallel](https://user-images.githubusercontent.com/17175564/50527646-b8cc2880-0afa-11e9-9b83-a728869b473c.png)

After:
![parallel](https://user-images.githubusercontent.com/17175564/50527647-b8cc2880-0afa-11e9-850c-648cc8bc6607.png)
