### PR TITLE
Added search intent handler and Google Search Action, for the global search

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,8 +29,10 @@
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH" />
+                <action android:name="com.google.android.gms.actions.SEARCH_ACTION"/>
+                <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
-
+            <meta-data android:name="android.app.searchable" android:resource="@xml/searchable"/>
             <!--suppress AndroidDomInspection -->
             <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts"/>
         </activity>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,9 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEARCH" />
+            </intent-filter>
 
             <!--suppress AndroidDomInspection -->
             <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts"/>

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.ui.main
 
 import android.animation.ObjectAnimator
+import android.app.SearchManager
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
@@ -15,6 +16,7 @@ import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.ui.base.activity.BaseActivity
 import eu.kanade.tachiyomi.ui.base.controller.*
 import eu.kanade.tachiyomi.ui.catalogue.CatalogueController
+import eu.kanade.tachiyomi.ui.catalogue.global_search.CatalogueSearchController
 import eu.kanade.tachiyomi.ui.download.DownloadController
 import eu.kanade.tachiyomi.ui.extension.ExtensionController
 import eu.kanade.tachiyomi.ui.library.LibraryController
@@ -156,6 +158,13 @@ class MainActivity : BaseActivity() {
             SHORTCUT_DOWNLOADS -> {
                 if (router.backstack.none { it.controller() is DownloadController }) {
                     setSelectedDrawerItem(R.id.nav_drawer_downloads)
+                }
+            }
+            Intent.ACTION_SEARCH -> {
+                setSelectedDrawerItem(R.id.nav_drawer_catalogues)
+                //Get the search query provided in extras, and if not null, perform a global search with it.
+                intent.getStringExtra(SearchManager.QUERY)?.also { query ->
+                    router.pushController(CatalogueSearchController(query).withFadeTransaction())
                 }
             }
             else -> return false

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -160,7 +160,10 @@ class MainActivity : BaseActivity() {
                     setSelectedDrawerItem(R.id.nav_drawer_downloads)
                 }
             }
-            Intent.ACTION_SEARCH -> {
+            Intent.ACTION_SEARCH, "com.google.android.gms.actions.SEARCH_ACTION" -> {
+                //If the intent match the "standard" Android search intent
+                // or the Google-specific search intent (triggered by saying or typing "search *query* on *Tachiyomi*" in Google Search/Google Assistant)
+
                 setSelectedDrawerItem(R.id.nav_drawer_catalogues)
                 //Get the search query provided in extras, and if not null, perform a global search with it.
                 intent.getStringExtra(SearchManager.QUERY)?.also { query ->

--- a/app/src/main/res/xml/searchable.xml
+++ b/app/src/main/res/xml/searchable.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<searchable xmlns:android="http://schemas.android.com/apk/res/android"
+    android:label="@string/app_name"
+    android:hint="@string/action_global_search_hint" >
+</searchable>


### PR DESCRIPTION
- [x] Allows to launch a global search for a manga, from an external app/shortcut/command, with the standard search intent. 

     It can be used to speed up/automate manga searches from a known list, with automation apps (like Tasker/Automate). I thought of this with #1774, it could help mass import tracking lists - you could automate the search of items of your AniList for example.

- [x] Also added support for Google Search Actions
    Anyone can now say or type "Search *manga* in Tachiyomi", either to Google Assistant or directly on the Google app, and be redirected to the search results in Tachiyomi

Note about future UI improvements, 1.x or later :
Currently Tachiyomi's "global search" is made to search items in catalogs and not in the library. I believe it would be more relevant for a Google Search to show a search activity with Library results on top, and then Catalog results - basically, a global "global search to satisfy both the users searching something in their library, and the ones looking to add a new manga.
Since I think you've mentioned some UI changes for 1.x, I'll wait until then to start thinking about that