### PR TITLE
Fix date parsing error on Anilist search

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -12,6 +12,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import rx.Observable
+import java.util.Calendar
 
 
 class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
@@ -246,10 +247,18 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
     }
 
     fun jsonToALManga(struct: JsonObject): ALManga{
+        val date = try {
+            val date = Calendar.getInstance()
+            date.set(struct["startDate"]["year"].nullInt ?: 0, (struct["startDate"]["month"].nullInt ?: 0) - 1,
+                    struct["startDate"]["day"].nullInt ?: 0)
+            date.timeInMillis
+        } catch (_: Exception) {
+            0L
+        }
+
         return ALManga(struct["id"].asInt, struct["title"]["romaji"].asString, struct["coverImage"]["large"].asString,
                 struct["description"].nullString.orEmpty(), struct["type"].asString, struct["status"].asString,
-                struct["startDate"]["year"].nullString.orEmpty() + struct["startDate"]["month"].nullString.orEmpty()
-                        + struct["startDate"]["day"].nullString.orEmpty(), struct["chapters"].nullInt ?: 0)
+                date, struct["chapters"].nullInt ?: 0)
     }
 
     fun jsonToALUserManga(struct: JsonObject): ALUserManga{

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistModels.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.data.track.anilist
 
-import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.preference.getOrDefault
@@ -17,7 +16,7 @@ data class ALManga(
         val description: String?,
         val type: String,
         val publishing_status: String,
-        val start_date_fuzzy: String,
+        val start_date_fuzzy: Long,
         val total_chapters: Int) {
 
     fun toTrack() = TrackSearch.create(TrackManager.ANILIST).apply {
@@ -29,14 +28,12 @@ data class ALManga(
         tracking_url = AnilistApi.mangaUrl(media_id)
         publishing_status = this@ALManga.publishing_status
         publishing_type = type
-        if (!start_date_fuzzy.isNullOrBlank()) {
+        if (start_date_fuzzy != 0L) {
             start_date = try {
-                val inputDf = SimpleDateFormat("yyyyMMdd", Locale.US)
                 val outputDf = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-                val date = inputDf.parse(BuildConfig.BUILD_TIME)
-                outputDf.format(date)
+                outputDf.format(start_date_fuzzy)
             } catch (e: Exception) {
-                start_date_fuzzy.orEmpty()
+                ""
             }
         }
     }


### PR DESCRIPTION
fix #1804

also this is my first PR.

It was fixed to `BuildConfig.BUILD_TIME`. so when it's stable, it only shows `2017-10-31`

What is fixed in a commit is 
 1. Date parse error due to no paddings. (`AnilistApi.kt`, `AnilistModels.kt`). [Thanks to Flat in #1804](https://github.com/inorichi/tachiyomi/issues/1804#issuecomment-454407099)
 2. Fixed value to actual dates. (`AnilistModels.kt`)

| From(stable) | To |
| - | - |
| <img src="https://user-images.githubusercontent.com/45893338/51181017-61f18c00-190d-11e9-8a3d-7c4800ec7fae.png" width="350px"/> | ![b](https://user-images.githubusercontent.com/45893338/51216046-5da58d00-1966-11e9-840f-80babf3a9588.png) |

Codes may dirty.