### PR TITLE
Fix bug with update lib and parse chapters

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterSourceSync.kt
@@ -51,7 +51,11 @@ fun syncChaptersWithSource(db: DatabaseHelper,
             toAdd.add(sourceChapter)
         } else {
             //this forces metadata update for the main viewable things in the chapter list
-            ChapterRecognition.parseChapterNumber(sourceChapter, manga)
+            if (source is HttpSource) {
+                source.prepareNewChapter(sourceChapter, manga)
+            } else {
+                ChapterRecognition.parseChapterNumber(sourceChapter, manga)
+            }
             if (shouldUpdateDbChapter(dbChapter, sourceChapter)) {
                 dbChapter.scanlator = sourceChapter.scanlator
                 dbChapter.name = sourceChapter.name

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterSourceSync.kt
@@ -53,9 +53,10 @@ fun syncChaptersWithSource(db: DatabaseHelper,
             //this forces metadata update for the main viewable things in the chapter list
             if (source is HttpSource) {
                 source.prepareNewChapter(sourceChapter, manga)
-            } else {
-                ChapterRecognition.parseChapterNumber(sourceChapter, manga)
             }
+
+            ChapterRecognition.parseChapterNumber(sourceChapter, manga)
+
             if (shouldUpdateDbChapter(dbChapter, sourceChapter)) {
                 dbChapter.scanlator = sourceChapter.scanlator
                 dbChapter.name = sourceChapter.name


### PR DESCRIPTION
Hey, i found a bug. If source has custom prepareNewChapter -  this method: https://github.com/inorichi/tachiyomi/blob/master/app/src/main/java/eu/kanade/tachiyomi/util/ChapterSourceSync.kt#L54 will override this in library update.

