### PR TITLE
Add options to open catalogue in browser/webview

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCatalogueController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCatalogueController.kt
@@ -17,11 +17,13 @@ import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.base.controller.NucleusController
 import eu.kanade.tachiyomi.ui.base.controller.SecondaryDrawerController
 import eu.kanade.tachiyomi.ui.base.controller.withFadeTransaction
 import eu.kanade.tachiyomi.ui.library.ChangeMangaCategoriesDialog
 import eu.kanade.tachiyomi.ui.manga.MangaController
+import eu.kanade.tachiyomi.ui.manga.info.MangaWebViewController
 import eu.kanade.tachiyomi.util.*
 import eu.kanade.tachiyomi.widget.AutofitRecyclerView
 import kotlinx.android.synthetic.main.catalogue_controller.*
@@ -259,13 +261,36 @@ open class BrowseCatalogueController(bundle: Bundle) :
         }
     }
 
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+
+        val isHttpSource = presenter.source is HttpSource
+        menu.findItem(R.id.action_open_in_browser).isVisible = isHttpSource
+        menu.findItem(R.id.action_open_in_web_view).isVisible = isHttpSource
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.action_display_mode -> swapDisplayMode()
             R.id.action_set_filter -> navView?.let { activity?.drawer?.openDrawer(Gravity.END) }
+            R.id.action_open_in_browser -> openInBrowser()
+            R.id.action_open_in_web_view -> openInWebView()
             else -> return super.onOptionsItemSelected(item)
         }
         return true
+    }
+
+    private fun openInBrowser() {
+        val source = presenter.source as? HttpSource ?: return
+
+        activity?.openInBrowser(source.baseUrl)
+    }
+
+    private fun openInWebView() {
+        val source = presenter.source as? HttpSource ?: return
+
+        router.pushController(MangaWebViewController(source.id, source.baseUrl)
+                .withFadeTransaction())
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -42,6 +42,7 @@ import eu.kanade.tachiyomi.ui.library.ChangeMangaCategoriesDialog
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.manga.MangaController
 import eu.kanade.tachiyomi.util.getResourceColor
+import eu.kanade.tachiyomi.util.openInBrowser
 import eu.kanade.tachiyomi.util.snack
 import eu.kanade.tachiyomi.util.toast
 import eu.kanade.tachiyomi.util.truncateCenter
@@ -287,15 +288,7 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
         val context = view?.context ?: return
         val source = presenter.source as? HttpSource ?: return
 
-        try {
-            val url = Uri.parse(source.mangaDetailsRequest(presenter.manga).url().toString())
-            val intent = CustomTabsIntent.Builder()
-                    .setToolbarColor(context.getResourceColor(R.attr.colorPrimary))
-                    .build()
-            intent.launchUrl(activity, url)
-        } catch (e: Exception) {
-            context.toast(e.message)
-        }
+        context.openInBrowser(source.mangaDetailsRequest(presenter.manga).url().toString())
     }
 
     private fun openInWebView() {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/ContextExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ContextExtensions.kt
@@ -10,14 +10,17 @@ import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.content.res.Resources
 import android.net.ConnectivityManager
+import android.net.Uri
 import android.os.PowerManager
 import android.support.annotation.AttrRes
 import android.support.annotation.StringRes
+import android.support.customtabs.CustomTabsIntent
 import android.support.v4.app.NotificationCompat
 import android.support.v4.content.ContextCompat
 import android.support.v4.content.LocalBroadcastManager
 import android.widget.Toast
 import com.nononsenseapps.filepicker.FilePickerActivity
+import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.widget.CustomLayoutPickerActivity
 
 /**
@@ -162,4 +165,19 @@ fun Context.isServiceRunning(serviceClass: Class<*>): Boolean {
     @Suppress("DEPRECATION")
     return manager.getRunningServices(Integer.MAX_VALUE)
             .any { className == it.service.className }
+}
+
+/**
+ * Opens a URL in a custom tab.
+ */
+fun Context.openInBrowser(url: String) {
+    try {
+        val url = Uri.parse(url)
+        val intent = CustomTabsIntent.Builder()
+                .setToolbarColor(getResourceColor(R.attr.colorPrimary))
+                .build()
+        intent.launchUrl(this, url)
+    } catch (e: Exception) {
+        toast(e.message)
+    }
 }

--- a/app/src/main/res/menu/catalogue_list.xml
+++ b/app/src/main/res/menu/catalogue_list.xml
@@ -19,4 +19,15 @@
         android:id="@+id/action_display_mode"
         android:title="@string/action_display_mode"
         app:showAsAction="ifRoom"/>
+
+    <item
+        android:id="@+id/action_open_in_browser"
+        android:title="@string/action_open_in_browser"
+        app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/action_open_in_web_view"
+        android:title="@string/action_open_in_web_view"
+        app:showAsAction="never"/>
+
 </menu>


### PR DESCRIPTION
Adds "Open in browser" and "Open in web view" menu items to the top level catalogue view, allowing users to navigate to a HTTP source catalogue's base URL.