### PR TITLE
Bugfix. Sharing images with very long name

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -434,7 +434,7 @@ class ReaderPresenter(
 
         // Build destination file.
         val filename = DiskUtil.buildValidFilename(
-                "${manga.title} - ${chapter.name}".dropLast(200)
+                "${manga.title} - ${chapter.name}".take(225)
         ) + " - ${page.number}.${type.extension}"
 
         val destFile = File(directory, filename)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -434,7 +434,8 @@ class ReaderPresenter(
 
         // Build destination file.
         val filename = DiskUtil.buildValidFilename(
-                "${manga.title} - ${chapter.name}") + " - ${page.number}.${type.extension}"
+                "${manga.title} - ${chapter.name}".dropLast(200)
+        ) + " - ${page.number}.${type.extension}"
 
         val destFile = File(directory, filename)
         stream().use { input ->


### PR DESCRIPTION
Fix sharing images, which generate very long image name for sharing. 
Currently ocures on readmanga parser - this manga: http://readmanga.me/neveroiatnye_prikliucheniia_djodjo_chast_8__djodjolion__cvetnaia_versiia_

