### PR TITLE
Change versionCode on debug version

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -5,7 +5,7 @@ git fetch --unshallow #required for commit count
 cp .travis/google-services.json app/
 
 if [ -z "$TRAVIS_TAG" ]; then
-    ./gradlew clean assembleStandardDebug
+    ./gradlew clean assembleFdroid-devDebug
 
     COMMIT_COUNT=$(git rev-list --count HEAD)
     export ARTIFACT="tachiyomi-r${COMMIT_COUNT}.apk"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,7 +77,7 @@ android {
             minSdkVersion 21
             resConfigs "en", "xxhdpi"
             dimension "default"
-            versionCode getCommitCount()
+            versionCode getCommitCount().toInteger()
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,7 +79,7 @@ android {
         dev {
             minSdkVersion 21
             resConfigs "en", "xxhdpi"
-            dimension "default"            
+            dimension "default"
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,6 @@ android {
         minSdkVersion 16
         targetSdkVersion 27
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        versionCode 41
         versionName "0.8.4"
 
         buildConfigField "String", "COMMIT_COUNT", "\"${getCommitCount()}\""
@@ -68,9 +67,11 @@ android {
         standard {
             buildConfigField "boolean", "INCLUDE_UPDATER", "true"
             dimension "default"
+            versionCode 41
         }
         fdroid {
             dimension "default"
+            versionCode 41
         }
         dev {
             minSdkVersion 21

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,7 @@ android {
 
     buildTypes {
         debug {
+            versionCode ${getCommitCount()}
             versionNameSuffix "-${getCommitCount()}"
             applicationIdSuffix ".debug"
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 27
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        versionCode 41
         versionName "0.8.4"
 
         buildConfigField "String", "COMMIT_COUNT", "\"${getCommitCount()}\""
@@ -67,17 +68,18 @@ android {
         standard {
             buildConfigField "boolean", "INCLUDE_UPDATER", "true"
             dimension "default"
-            versionCode 41
         }
         fdroid {
             dimension "default"
-            versionCode 41
+        }
+        fdroid-dev {
+            dimension "default"
+            versionCode getCommitCount().toInteger()
         }
         dev {
             minSdkVersion 21
             resConfigs "en", "xxhdpi"
-            dimension "default"
-            versionCode getCommitCount().toInteger()
+            dimension "default"            
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,6 @@ android {
 
     buildTypes {
         debug {
-            versionCode getCommitCount()
             versionNameSuffix "-${getCommitCount()}"
             applicationIdSuffix ".debug"
         }
@@ -77,6 +76,7 @@ android {
             minSdkVersion 21
             resConfigs "en", "xxhdpi"
             dimension "default"
+            versionCode getCommitCount()
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ android {
 
     buildTypes {
         debug {
-            versionCode "${getCommitCount()}".toInteger()
+            versionCode getCommitCount()
             versionNameSuffix "-${getCommitCount()}"
             applicationIdSuffix ".debug"
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ android {
 
     buildTypes {
         debug {
-            versionCode ${getCommitCount()}
+            versionCode "${getCommitCount()}".toInteger()
             versionNameSuffix "-${getCommitCount()}"
             applicationIdSuffix ".debug"
         }


### PR DESCRIPTION
Would this work?  If so it'd make my job much easier, because my build infrastructure was breaking all the time, to the point I discontinued the fdroid server. This way I could just get the apk's from http://tachiyomi.kanade.eu/latest let's say once an hour and be done with it. I can't do that now, because fdroid requires the version code to change with updates.

The interest in autoupdated dev versions seems to be higher than I thought: https://discordapp.com/channels/349436576037732353/411962173598990340/563415246530805771