### PR TITLE
Auto fit page charset when use Response.asJsoup.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/JsoupExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/JsoupExtensions.kt
@@ -22,5 +22,18 @@ fun Element.attrOrText(css: String): String {
  * @param html the body of the response. Use only if the body was read before calling this method.
  */
 fun Response.asJsoup(html: String? = null): Document {
-    return Jsoup.parse(html ?: body()!!.string(), request().url().toString())
+    return Jsoup.parse(html ?: bodyWithAutoCharset(), request().url().toString())
+}
+
+fun Response.bodyWithAutoCharset(_charset: String? = null): String {
+    val htmlBytes: ByteArray = body()!!.bytes()
+    var c = _charset
+
+    if (c == null) {
+        var regexPat = Regex("""charset=(\w+)""")
+        val match = regexPat.find(String(htmlBytes))
+        c = match?.groups?.get(1)?.value
+    }
+
+    return String(htmlBytes, charset(c ?: "utf8"))
 }


### PR DESCRIPTION
Fixed the use of asJsoup method to cause garbled characters in non-utf-8 encoded web pages when adapting to non-English websites (eg: GBK)