### PR TITLE
Hide Empty Search Results in Catalogues

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchHolder.kt
@@ -55,14 +55,17 @@ class CatalogueSearchHolder(view: View, val adapter: CatalogueSearchAdapter) :
             results == null -> {
                 progress.visible()
                 nothing_found.gone()
+                showHolder()
             }
             results.isEmpty() -> {
                 progress.gone()
                 nothing_found.visible()
+                hideHolder()
             }
             else -> {
                 progress.gone()
                 nothing_found.gone()
+                showHolder()
             }
         }
         if (results !== lastBoundResults) {
@@ -96,4 +99,15 @@ class CatalogueSearchHolder(view: View, val adapter: CatalogueSearchAdapter) :
 
         return null
     }
+
+    private fun showHolder() {
+        title.visible()
+        source_card.visible()
+    }
+
+    private fun hideHolder() {
+        title.gone()
+        source_card.gone()
+    }
+
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchHolder.kt
@@ -31,9 +31,6 @@ class CatalogueSearchHolder(view: View, val adapter: CatalogueSearchAdapter) :
         // Set layout horizontal.
         recycler.layoutManager = LinearLayoutManager(view.context, LinearLayoutManager.HORIZONTAL, false)
         recycler.adapter = mangaAdapter
-
-        nothing_found_icon.setVectorCompat(R.drawable.ic_search_black_112dp,
-                view.context.getResourceColor(android.R.attr.textColorHint))
     }
 
     /**
@@ -54,17 +51,14 @@ class CatalogueSearchHolder(view: View, val adapter: CatalogueSearchAdapter) :
         when {
             results == null -> {
                 progress.visible()
-                nothing_found.gone()
                 showHolder()
             }
             results.isEmpty() -> {
                 progress.gone()
-                nothing_found.visible()
                 hideHolder()
             }
             else -> {
                 progress.gone()
-                nothing_found.gone()
                 showHolder()
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchPresenter.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.LoginSource
 import eu.kanade.tachiyomi.ui.base.presenter.BasePresenter
@@ -159,7 +160,7 @@ open class CatalogueSearchPresenter(
                 .flatMap({ source ->
                     source.fetchSearchManga(1, query, FilterList())
                             .subscribeOn(Schedulers.io())
-                            .onExceptionResumeNext(Observable.empty()) // Ignore timeouts.
+                            .onExceptionResumeNext(Observable.just(MangasPage(emptyList(), false))) // Ignore timeouts.
                             .map { it.mangas.take(10) } // Get at most 10 manga from search result.
                             .map { it.map { networkToLocalManga(it, source.id) } } // Convert to local manga.
                             .doOnNext { fetchImage(it, source) } // Load manga covers.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/global_search/CatalogueSearchPresenter.kt
@@ -10,7 +10,6 @@ import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.FilterList
-import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.LoginSource
 import eu.kanade.tachiyomi.ui.base.presenter.BasePresenter
@@ -160,7 +159,7 @@ open class CatalogueSearchPresenter(
                 .flatMap({ source ->
                     source.fetchSearchManga(1, query, FilterList())
                             .subscribeOn(Schedulers.io())
-                            .onExceptionResumeNext(Observable.just(MangasPage(emptyList(), false))) // Ignore timeouts.
+                            .onExceptionResumeNext(Observable.empty()) // Ignore timeouts.
                             .map { it.mangas.take(10) } // Get at most 10 manga from search result.
                             .map { it.map { networkToLocalManga(it, source.id) } } // Convert to local manga.
                             .doOnNext { fetchImage(it, source) } // Load manga covers.

--- a/app/src/main/res/drawable/ic_search_black_112dp.xml
+++ b/app/src/main/res/drawable/ic_search_black_112dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="112dp"
-    android:height="112dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0">
-    <path
-        android:fillColor="#FF000000"
-        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z" />
-</vector>

--- a/app/src/main/res/layout/catalogue_global_search_controller_card.xml
+++ b/app/src/main/res/layout/catalogue_global_search_controller_card.xml
@@ -36,41 +36,6 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center" />
 
-        <android.support.constraint.ConstraintLayout
-            android:id="@+id/nothing_found"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:visibility="gone">
-
-            <ImageView
-                android:id="@+id/nothing_found_icon"
-                android:layout_width="112dp"
-                android:layout_height="112dp"
-                android:scaleType="fitCenter"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:ignore="ContentDescription"
-                tools:src="@mipmap/ic_launcher" />
-
-            <TextView
-                android:id="@+id/nothing_found_text"
-                style="@style/TextAppearance.Regular.Caption.Hint"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="0dp"
-                android:ellipsize="end"
-                android:gravity="center"
-                android:maxLines="1"
-                android:paddingBottom="8dp"
-                android:text="@string/no_results"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/nothing_found_icon" />
-
-        </android.support.constraint.ConstraintLayout>
-
         <android.support.v7.widget.RecyclerView
             android:id="@+id/recycler"
             android:layout_width="match_parent"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -266,7 +266,6 @@
     <string name="invalid_combination">لا يمكن تحديد الإعداد الافتراضي مع الفئات الأخرى</string>
     <string name="added_to_library">تم إضافة المانجا إلى مكتبتك</string>
     <string name="action_global_search_hint">البحث الشامل…</string>
-    <string name="no_results">لا توجد نتائج!</string>
     <string name="latest">اﻷخيرة</string>
     <string name="browse">تصفح</string>
 

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -397,7 +397,6 @@
     <string name="action_login">Вход</string>
     <string name="other_source">Други</string>
     <string name="action_global_search_hint">Глобално търсене…</string>
-    <string name="no_results">Не бяха открити резултати!</string>
     <string name="latest">Последни</string>
     <string name="browse">Търсене</string>
     <string name="shortcut_created">Прекият път беше добавен към началния екран.</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -266,7 +266,6 @@
     <string name="invalid_combination">নির্ধারিতগুলো অন্যান্য ধরণের সাথে নির্বাচন করা যাবে না</string>
     <string name="added_to_library">মাংগাটি আপনার মাংগাশালায় যোগ হয়েছে</string>
     <string name="action_global_search_hint">সার্বজনীন খোঁজ…</string>
-    <string name="no_results">কোন ফলাফল পাওয়া যায়নি!</string>
     <string name="latest">সর্বশেষ</string>
     <string name="browse">ব্রাউজ</string>
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -134,7 +134,6 @@
     <string name="no_more_results">Žádné další výsledky</string>
     <string name="added_to_library">Manga byla přidána do vaší knihovny</string>
     <string name="action_global_search_hint">Globální vyhledávání…</string>
-    <string name="no_results">Žádné výsledky!</string>
     <string name="manga_not_in_db">Manga byla odstraněna z databáze!</string>
     <string name="manga_detail_tab">Info</string>
     <string name="description">Popis</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -398,7 +398,6 @@
 
     <string name="other_source">Andere</string>
     <string name="action_global_search_hint">Globale Suche…</string>
-    <string name="no_results">Keine Treffer gefunden!</string>
     <string name="latest">Letzte</string>
     <string name="browse">Umsehen</string>
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -301,7 +301,6 @@
     <string name="added_to_library">Το manga έχει προστεθεί στη βιβλιοθήκη σας
 \n</string>
     <string name="action_global_search_hint">Καθολική αναζήτηση…</string>
-    <string name="no_results">Δεν βρέθηκαν αποτελέσματα!</string>
     <string name="latest">Τελευταίο</string>
     <string name="browse">Ξεφύλλισμα</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -395,7 +395,6 @@ También asegúrese de haber iniciado sesión en las fuentes que lo requieren an
     <string name="local_source_badge">Local</string>
     <string name="other_source">Otros</string>
     <string name="action_global_search_hint">Búsqueda global…</string>
-    <string name="no_results">Ningún resultado encontrado!</string>
     <string name="latest">Recientes</string>
     <string name="browse">Explorar</string>
     <string name="shortcut_created">Acceso directo fue agregado a la pantalla de inicio.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -396,7 +396,6 @@ Assurez-vous que vous êtes connecté à des sources qui le demande avant de com
     <string name="action_login">Connexion</string>
     <string name="other_source">Autre</string>
     <string name="action_global_search_hint">Recherche globale…</string>
-    <string name="no_results">Aucun résultat !</string>
     <string name="latest">Récents</string>
     <string name="browse">Explorer</string>
     <string name="shortcut_created">Un raccourci a été ajouté à la page d\'accueil.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -250,7 +250,6 @@
     <string name="invalid_combination">डिफ़ॉल्ट को अन्य श्रेणियों के साथ नहीं चुना जा सकता है</string>
     <string name="added_to_library">मंगा को आपकी लाइब्रेरी में जोड़ा गया है</string>
     <string name="action_global_search_hint">वैश्विक खोज …</string>
-    <string name="no_results">कोई परिणाम नहीं मिला!</string>
     <string name="latest">नवीनतम</string>
     <string name="browse">ब्राउज</string>
     <string name="manga_not_in_db">यह मंगा डेटाबेस से हटा दिया गया था!</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -400,7 +400,6 @@
     <string name="local_source_badge">Lokal</string>
     <string name="other_source">Lainnya</string>
     <string name="action_global_search_hint">Pencarian global…</string>
-    <string name="no_results">Tidak ada hasil!</string>
     <string name="latest">Terbaru</string>
     <string name="browse">Jelajahi</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -476,7 +476,6 @@
     <string name="other_source">Altro</string>
     <string name="invalid_combination">Predefinito non può essere selezionato con altre categorie</string>
     <string name="action_global_search_hint">Ricerca globale…</string>
-    <string name="no_results">Nessun risultato!</string>
     <string name="latest">Ultimi</string>
     <string name="browse">Sfoglia</string>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -237,7 +237,6 @@
     <string name="no_valid_sources">최소한 1개의 유효한 소스를 선택해주세요</string>
     <string name="no_more_results">더이상 결과 없음</string>
     <string name="action_global_search_hint">전역 검색…</string>
-    <string name="no_results">결과가 없습니다!</string>
     <string name="latest">최신</string>
     <string name="manga_detail_tab">정보</string>
     <string name="description">설명</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -268,7 +268,6 @@
     <string name="invalid_combination">Lalai tidak boleh dipilih bersama kategori lain</string>
     <string name="added_to_library">Manga ini telah ditambahkan ke koleksi anda</string>
     <string name="action_global_search_hint">Carian keseluruhan…</string>
-    <string name="no_results">Tiada sebarang hasil!</string>
     <string name="latest">Terkini</string>
     <string name="browse">Semak imbas</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -365,7 +365,6 @@ Zorg ook dat je ingelogd bent voor bronnen die dit vereisen alvorens je het teru
     <string name="local_source_badge">Lokaal</string>
     <string name="other_source">Alternatief</string>
     <string name="action_global_search_hint">Globaal zoeken…</string>
-    <string name="no_results">Geen resultaten gevonden!</string>
     <string name="latest">Recent</string>
     <string name="shortcut_created">Snelkoppeling toegevoegd aan startscherm.</string>
     <string name="channel_library">Bibliotheek</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -398,7 +398,6 @@ Nie znaleziono źródła %1$s</string>
 
     <string name="other_source">Inne</string>
     <string name="action_global_search_hint">Wyszukiwanie globalne…</string>
-    <string name="no_results">Brak wyników!</string>
     <string name="browse">Przeglądaj</string>
 
     <string name="shortcut_created">Skrót został dodany do ekranu głównego.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -362,7 +362,6 @@ Além disso, verifique se as fontes que requerem uma conta foram configuradas co
     <string name="action_login">Entrar</string>
     <string name="other_source">Outras</string>
     <string name="action_global_search_hint">Pesquisa global…</string>
-    <string name="no_results">Nenhum resultado encontrado!</string>
     <string name="latest">Mais recente</string>
     <string name="browse">Navegar</string>
     <string name="shortcut_created">O atalho foi adicionado à sua tela inicial.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -299,7 +299,6 @@
     <string name="invalid_combination">Modul implicit nu poate fi selectat cu alte categorii</string>
     <string name="added_to_library">Manga-ul a fost adăugat bibliotecii tale</string>
     <string name="action_global_search_hint">Căutare globală…</string>
-    <string name="no_results">Nici un rezultat găsit!</string>
     <string name="latest">Cel mai recent</string>
     <string name="browse">Caută</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -360,7 +360,6 @@
     <string name="local_source_badge">Локальная</string>
     <string name="other_source">Другие</string>
     <string name="action_global_search_hint">Глобальный поиск…</string>
-    <string name="no_results">Результат не найден!</string>
     <string name="latest">Последняя</string>
     <string name="browse">Смотреть</string>
     <string name="shortcut_created">Ярлык был добавлен на главный экран.</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -283,7 +283,6 @@
     <string name="invalid_combination">Predefinidu non podet èssere ischertadu cun àteras categorias</string>
     <string name="added_to_library">Su manga est istadu annantu a sa biblioteca tua</string>
     <string name="action_global_search_hint">Chirca globale…</string>
-    <string name="no_results">Perunu risultadu agatadu!</string>
     <string name="latest">Ùrtimos</string>
     <string name="browse">Esplora</string>
     <string name="manga_not_in_db">Custu manga est istadu bogadu dae sa base de datos!</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -283,7 +283,6 @@
     <string name="invalid_combination">Opšte je nemoguće označiti sa ostalim kategorijama</string>
     <string name="added_to_library">Ova manga je dodata u biblioteku</string>
     <string name="action_global_search_hint">Globalno pretraživanje…</string>
-    <string name="no_results">Nema pronađenih rezultata!</string>
     <string name="latest">Poslednje</string>
     <string name="browse">Pretraži</string>
     <string name="manga_not_in_db">Ova manga je uklonjena iz baze podataka!</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -300,7 +300,6 @@
     <string name="invalid_combination">Standard inte kan väljas med andra kategorier</string>
     <string name="added_to_library">Mangan har lagts till i din bibliotek</string>
     <string name="action_global_search_hint">Global sökning…</string>
-    <string name="no_results">Inga resultat hittades!</string>
     <string name="latest">Senaste</string>
     <string name="browse">Bläddra</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -281,7 +281,6 @@
     <string name="invalid_combination">Öntanımlı diğer kategorilerle birlikte seçilemez</string>
     <string name="added_to_library">Manga kitaplığınıza eklendi</string>
     <string name="action_global_search_hint">Genel arama…</string>
-    <string name="no_results">Sonuç bulunmadı!</string>
     <string name="latest">En son</string>
     <string name="browse">Göz at</string>
     <string name="manga_not_in_db">Bu manga veritabanından kaldırıldı!</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -282,7 +282,6 @@
     <string name="invalid_combination">Категорія за замовчуванням не може бути вибраною разом з іншими категоріями</string>
     <string name="added_to_library">Цю мангу уже додано до бібліотеки</string>
     <string name="action_global_search_hint">Глобальний пошук…</string>
-    <string name="no_results">Результатів не знайдено!</string>
     <string name="latest">Остання</string>
     <string name="browse">Переглянути</string>
     <string name="manga_not_in_db">Ця манга було видалена з бази даних!</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -461,7 +461,6 @@
     <string name="invalid_combination">Mặc định không thể chọn với các danh mục khác</string>
     <string name="added_to_library">Truyện này đã được thêm vào thư viện</string>
     <string name="action_global_search_hint">Tìm kiếm toàn cầu…</string>
-    <string name="no_results">Không tìm thấy kết quả!</string>
     <string name="latest">Mới nhất</string>
     <string name="browse">Duyệt</string>
     <string name="manga_info_full_title_label">Tiêu đề</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -281,7 +281,6 @@
     <string name="invalid_combination">默认标签不能与其它标签一起选择</string>
     <string name="added_to_library">已将此漫画添加至书架</string>
     <string name="action_global_search_hint">全局搜索…</string>
-    <string name="no_results">找不到！</string>
     <string name="latest">最近更新</string>
     <string name="browse">浏览</string>
     <string name="manga_not_in_db">漫画已被移出数据库！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,7 +326,6 @@
     <string name="invalid_combination">Default can\'t be selected with other categories</string>
     <string name="added_to_library">The manga has been added to your library</string>
     <string name="action_global_search_hint">Global search…</string>
-    <string name="no_results">No results found!</string>
     <string name="latest">Latest</string>
     <string name="browse">Browse</string>
 


### PR DESCRIPTION
Solves https://github.com/inorichi/tachiyomi/issues/1732 https://github.com/inorichi/tachiyomi/issues/1809

Not sure on the exact UI (i.e. keep or hide the catalogue title), and if whether or not this should be in settings (can probably just remove the nothing_found view if not).

Also didn't see any value in showing a loading circle for catalogues that error out, so changed it to return an empty result.