### PR TITLE
Fix sync chapters when source deletes all chapters

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/ChapterSourceSync.kt
@@ -22,12 +22,12 @@ fun syncChaptersWithSource(db: DatabaseHelper,
                            manga: Manga,
                            source: Source): Pair<List<Chapter>, List<Chapter>> {
 
-    if (rawSourceChapters.isEmpty()) {
-        throw Exception("No chapters found")
-    }
-
     // Chapters from db.
     val dbChapters = db.getChapters(manga).executeAsBlocking()
+
+    if (rawSourceChapters.isEmpty() && dbChapters.isEmpty()) {
+        throw Exception("No chapters found")
+    }
 
     val sourceChapters = rawSourceChapters.mapIndexed { i, sChapter ->
         Chapter.create().apply {
@@ -132,6 +132,11 @@ fun syncChaptersWithSource(db: DatabaseHelper,
         manga.last_update = Date().time
         db.updateLastUpdated(manga).executeAsBlocking()
     }
+
+    if (rawSourceChapters.isEmpty()) {
+        throw Exception("No chapters found")
+    }
+
     return Pair(toAdd.subtract(readded).toList(), toDelete.subtract(readded).toList())
 
 }


### PR DESCRIPTION
Handles case where all chapters from the source have been removed (as is the case in the recent Mangadex incident). 

Expected
I expect any local chapters to also be removed accordingly.