### PR TITLE
Travis Builds Failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: android
 android:
   components:


### PR DESCRIPTION
Most likely due to Travis starting to migrate default environment from trusty to xenial starting from 2 months ago. https://changelog.travis-ci.com/