### PR TITLE
Allow back button to navigate to previous URL in WebView

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaWebViewController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaWebViewController.kt
@@ -1,9 +1,7 @@
 package eu.kanade.tachiyomi.ui.manga.info
 
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import android.webkit.WebView
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.source.SourceManager
@@ -15,6 +13,10 @@ import uy.kohesive.injekt.injectLazy
 class MangaWebViewController(bundle: Bundle? = null) : BaseController(bundle) {
 
     private val sourceManager by injectLazy<SourceManager>()
+
+    init {
+        setHasOptionsMenu(true)
+    }
 
     constructor(sourceId: Long, url: String) : this(Bundle().apply {
         putLong(SOURCE_KEY, sourceId)
@@ -41,6 +43,40 @@ class MangaWebViewController(bundle: Bundle? = null) : BaseController(bundle) {
         web.settings.javaScriptEnabled = true
         web.settings.userAgentString = source.headers["User-Agent"]
         web.loadUrl(url, headers)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.web_view, menu)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        val web = view as WebView
+        menu.findItem(R.id.action_forward).isVisible = web.canGoForward()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            R.id.action_forward -> {
+                val web = view as WebView
+                if (web.canGoForward()) web.goForward()
+            }
+            R.id.action_refresh -> {
+                val web = view as WebView
+                web.reload()
+            }
+            R.id.action_close -> router.popController(this)
+            else -> return super.onOptionsItemSelected(item)
+        }
+        return true
+    }
+
+    override fun handleBack(): Boolean {
+        val web = view as WebView
+        if (web.canGoBack()) {
+            web.goBack()
+            return true
+        }
+        return super.handleBack()
     }
 
     override fun onDestroyView(view: View) {

--- a/app/src/main/res/menu/web_view.xml
+++ b/app/src/main/res/menu/web_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_forward"
+        android:title="@string/action_forward"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_refresh"
+        android:title="@string/action_refresh"
+        app:showAsAction="never" />
+
+    <item android:id="@+id/action_close"
+        android:title="@string/action_close"
+        app:showAsAction="never"/>
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,8 @@
     <string name="action_restore">Restore</string>
     <string name="action_open">Open</string>
     <string name="action_login">Log in</string>
+    <string name="action_forward">Forward</string>
+    <string name="action_refresh">Refresh</string>
 
     <!-- Operations -->
     <string name="deleting">Deleting…</string>


### PR DESCRIPTION
Adds Forward, Refresh, and Close actions to webview controller menu


-----------------------------------------------
Things before this should be merged:

- Do I need to null-check 'web' since view comes from getView() instead of a param?
- How do I add a 'close' menu item for the web view controller so that if a user gets stuck in e.g. an ad-loop they can force the whole WebView to close (as pressing back used to do here)?