### PR TITLE
Add .nomedia file in each chapter download folder

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -28,7 +28,9 @@ class DownloadProvider(private val context: Context) {
      * The root directory for downloads.
      */
     private var downloadsDir = preferences.downloadsDirectory().getOrDefault().let {
-        UniFile.fromUri(context, Uri.parse(it))
+        val dir = UniFile.fromUri(context, Uri.parse(it))
+        DiskUtil.createNoMediaFile(dir, context)
+        dir
     }
 
     init {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -407,6 +407,8 @@ class Downloader(
         if (download.status == Download.DOWNLOADED) {
             tmpDir.renameTo(dirname)
             cache.addChapter(dirname, mangaDir, download.manga)
+
+            DiskUtil.createNoMediaFile(tmpDir, context)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -17,7 +17,6 @@ import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.preference.getOrDefault
 import eu.kanade.tachiyomi.ui.base.controller.DialogController
-import eu.kanade.tachiyomi.util.DiskUtil
 import eu.kanade.tachiyomi.util.getFilePicker
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -45,15 +44,6 @@ class SettingsDownloadController : SettingsController() {
                     .subscribeUntilDestroy { path ->
                         val dir = UniFile.fromUri(context, Uri.parse(path))
                         summary = dir.filePath ?: path
-
-                        // Don't display downloaded chapters in gallery apps creating .nomedia
-                        if (dir != null && dir.exists()) {
-                            val nomedia = dir.findFile(".nomedia")
-                            if (nomedia == null) {
-                                dir.createFile(".nomedia")
-                                applicationContext?.let { DiskUtil.scanMedia(it, dir.uri) }
-                            }
-                        }
                     }
         }
         switchPreference {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/DiskUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/DiskUtil.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.os.Environment
 import android.support.v4.content.ContextCompat
 import android.support.v4.os.EnvironmentCompat
+import com.hippo.unifile.UniFile
 import java.io.File
 
 object DiskUtil {
@@ -52,6 +53,19 @@ object DiskUtil {
         }
 
         return directories
+    }
+
+    /**
+     * Don't display downloaded chapters in gallery apps creating `.nomedia`.
+     */
+    fun createNoMediaFile(dir: UniFile?, context: Context?) {
+        if (dir != null && dir.exists()) {
+            val nomedia = dir.findFile(".nomedia")
+            if (nomedia == null) {
+                dir.createFile(".nomedia")
+                context?.let { scanMedia(it, dir.uri) }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #2191, #2104.

Still not sure why the parent `.nomedia` doesn't always get created or why it doesn't seem to do anything for some people, but this is indeed the easiest workaround.