### PR TITLE
Implemented extension search functionality.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionGroupHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionGroupHolder.kt
@@ -11,6 +11,6 @@ class ExtensionGroupHolder(view: View, adapter: FlexibleAdapter<*>) :
 
     @SuppressLint("SetTextI18n")
     fun bind(item: ExtensionGroupItem) {
-        title.text = item.name + " (" + item.size + ")"
+        title.text = item.name
     }
 }

--- a/app/src/main/res/menu/extension_main.xml
+++ b/app/src/main/res/menu/extension_main.xml
@@ -1,0 +1,11 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_search"
+        android:title="@string/action_search"
+        android:icon="@drawable/ic_search_white_24dp"
+        app:showAsAction="collapseActionView|ifRoom"
+        app:actionViewClass="android.support.v7.widget.SearchView"/>
+
+</menu>


### PR DESCRIPTION
This is a quick implementation of searching for extensions. This PR adds a search menu icon on the extensions view, while also removing the extensions count per extensions group (because the count is set on ExtensionManager updates, which would be more expensive to recompute on every new search query). 

Closes #2202. 

Demo here:
https://imgur.com/rYwGVJK
