### PR TITLE
Change "Help" link from Github Wiki to Website

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -276,7 +276,7 @@ class MainActivity : BaseActivity() {
         const val INTENT_SEARCH_QUERY = "query"
         const val INTENT_SEARCH_FILTER = "filter"
 
-        private const val URL_HELP = "https://github.com/inorichi/tachiyomi/wiki"
+        private const val URL_HELP = "https://tachiyomi.org/help/"
     }
 
 }


### PR DESCRIPTION
Changed the GitHub Wiki help link in the menu to link the website instead.
The actual `/help/` page it would now link to isn't completely feature-complete but it does it's most important job and can re redirect the user to the Guides or FAQ section if they so choose.