### PR TITLE
fix jitpack shitting out

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        maven { url "https://jitpack.io" }
+        maven { url "https://www.jitpack.io" }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         jcenter()
     }


### PR DESCRIPTION
I can't believe this is an actual issue
https://github.com/jitpack/jitpack.io/issues/4002

Repro:
1. Clear out your gradle cache or do a fresh git clone
2. Try to build/sync
3. fail