### PR TITLE
Allow 'Default' category as the default for adding manga

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCatalogueController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCatalogueController.kt
@@ -500,19 +500,21 @@ open class BrowseCatalogueController(bundle: Bundle) :
             adapter?.notifyItemChanged(position)
 
             val categories = presenter.getCategories()
-            val defaultCategory = categories.find { it.id == preferences.defaultCategory() }
-            if (defaultCategory != null) {
-                presenter.moveMangaToCategory(manga, defaultCategory)
-            } else if (categories.size <= 1) { // default or the one from the user
-                presenter.moveMangaToCategory(manga, categories.firstOrNull())
-            } else {
-                val ids = presenter.getMangaCategoryIds(manga)
-                val preselected = ids.mapNotNull { id ->
-                    categories.indexOfFirst { it.id == id }.takeIf { it != -1 }
-                }.toTypedArray()
+            val defaultCategoryId = preferences.defaultCategory()
+            val defaultCategory = categories.find { it.id == defaultCategoryId }
+            when {
+                defaultCategory != null -> presenter.moveMangaToCategory(manga, defaultCategory)
+                defaultCategoryId == 0 || categories.isEmpty() -> // 'Default' or no category
+                    presenter.moveMangaToCategory(manga, null)
+                else -> {
+                    val ids = presenter.getMangaCategoryIds(manga)
+                    val preselected = ids.mapNotNull { id ->
+                        categories.indexOfFirst { it.id == id }.takeIf { it != -1 }
+                    }.toTypedArray()
 
-                ChangeMangaCategoriesDialog(this, listOf(manga), categories, preselected)
-                        .showDialog(router)
+                    ChangeMangaCategoriesDialog(this, listOf(manga), categories, preselected)
+                            .showDialog(router)
+                }
             }
             activity?.toast(activity?.getString(R.string.manga_added_library))
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCataloguePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCataloguePresenter.kt
@@ -316,9 +316,9 @@ open class BrowseCataloguePresenter(
     }
 
     /**
-     * Get the default, and user categories.
+     * Get user categories.
      *
-     * @return List of categories, default plus user categories
+     * @return List of categories, not including the default category
      */
     fun getCategories(): List<Category> {
         return db.getCategories().executeAsBlocking()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -382,11 +382,12 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
         toggleFavorite()
         if (manga.favorite) {
             val categories = presenter.getCategories()
-            val defaultCategory = categories.find { it.id == preferences.defaultCategory() }
+            val defaultCategoryId = preferences.defaultCategory()
+            val defaultCategory = categories.find { it.id == defaultCategoryId }
             when {
                 defaultCategory != null -> presenter.moveMangaToCategory(manga, defaultCategory)
-                categories.size <= 1 -> // default or the one from the user
-                    presenter.moveMangaToCategory(manga, categories.firstOrNull())
+                defaultCategoryId == 0 || categories.isEmpty() -> // 'Default' or no category
+                    presenter.moveMangaToCategory(manga, null)
                 else -> {
                     val ids = presenter.getMangaCategoryIds(manga)
                     val preselected = ids.mapNotNull { id ->
@@ -413,9 +414,9 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
             activity?.toast(activity?.getString(R.string.manga_added_library))
         }
         val categories = presenter.getCategories()
-        if (categories.size <= 1) {
-            // default or the one from the user then just add to favorite.
-            presenter.moveMangaToCategory(manga, categories.firstOrNull())
+        if (categories.isEmpty()) {
+            // no categories exist, display a message about adding categories
+            activity?.toast(activity?.getString(R.string.action_add_category))
         } else {
             val ids = presenter.getMangaCategoryIds(manga)
             val preselected = ids.mapNotNull { id ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoPresenter.kt
@@ -130,9 +130,9 @@ class MangaInfoPresenter(
     }
 
     /**
-     * Get the default, and user categories.
+     * Get user categories.
      *
-     * @return List of categories, default plus user categories
+     * @return List of categories, not including the default category
      */
     fun getCategories(): List<Category> {
         return db.getCategories().executeAsBlocking()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
@@ -8,6 +8,7 @@ import android.view.View
 import com.afollestad.materialdialogs.MaterialDialog
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
+import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.preference.getOrDefault
@@ -179,15 +180,17 @@ class SettingsGeneralController : SettingsController() {
             key = Keys.defaultCategory
             titleRes = R.string.default_category
 
-            val selectedCategory = dbCategories.find { it.id == preferences.defaultCategory() }
+            val categories = listOf(Category.createDefault()) + dbCategories
+
+            val selectedCategory = categories.find { it.id == preferences.defaultCategory() }
             entries = arrayOf(context.getString(R.string.default_category_summary)) +
-                    dbCategories.map { it.name }.toTypedArray()
-            entryValues = arrayOf("-1") + dbCategories.map { it.id.toString() }.toTypedArray()
+                    categories.map { it.name }.toTypedArray()
+            entryValues = arrayOf("-1") + categories.map { it.id.toString() }.toTypedArray()
             defaultValue = "-1"
             summary = selectedCategory?.name ?: context.getString(R.string.default_category_summary)
 
             onChange { newValue ->
-                summary = dbCategories.find {
+                summary = categories.find {
                     it.id == (newValue as String).toInt()
                 }?.name ?: context.getString(R.string.default_category_summary)
                 true


### PR DESCRIPTION
Default remains an implicit category, but is selectable in the 'default category to add to' setting and handled properly when only 1 non-implicit category exists.

I've tested most cases of this with a single user category as well as with multiple user categories, so it should be ready for review.