### PR TITLE
Two-Pages in Landscape Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Tachiyomi is a free and open source manga reader for Android.
 
 ![screenshots of app](./.github/readme-images/screens.png)
 
+##What is added in this fork
+
+Added an option to have landscape mode display two pages at once. When displaying two-pages at once tap to turn will transition 2 pages. When moving pages the app will check for a two-page spead and adjust accordingly (display the two pages over the screen).
+
 ## Features
 
 Features include:

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ Tachiyomi is a free and open source manga reader for Android.
 
 ![screenshots of app](./.github/readme-images/screens.png)
 
-## What is added in this fork
-
-Added an option to have landscape mode display two pages at once. When displaying two-pages at once tap to turn will transition 2 pages. When moving pages the app will check for a two-page spead and adjust accordingly (display the two pages over the screen).
-
 ## Features
 
 Features include:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Tachiyomi is a free and open source manga reader for Android.
 
 ![screenshots of app](./.github/readme-images/screens.png)
 
-##What is added in this fork
+## What is added in this fork
 
 Added an option to have landscape mode display two pages at once. When displaying two-pages at once tap to turn will transition 2 pages. When moving pages the app will check for a two-page spead and adjust accordingly (display the two pages over the screen).
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -9,6 +9,8 @@ object PreferenceKeys {
 
     const val rotation = "pref_rotation_type_key"
 
+    const val doublePageLandscape = "pref_two_page_key"
+
     const val enableTransitions = "pref_enable_transitions_key"
 
     const val doubleTapAnimationSpeed = "pref_double_tap_anim_speed"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -77,6 +77,8 @@ class PreferencesHelper(val context: Context) {
 
     fun readWithVolumeKeys() = rxPrefs.getBoolean(Keys.readWithVolumeKeys, false)
 
+    fun landscapeMode() = rxPrefs.getInteger(Keys.doublePageLandscape, 1)
+
     fun readWithVolumeKeysInverted() = rxPrefs.getBoolean(Keys.readWithVolumeKeysInverted, false)
 
     fun portraitColumns() = rxPrefs.getInteger(Keys.portraitColumns, 0)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -43,6 +43,9 @@ class PagerConfig(private val viewer: PagerViewer, preferences: PreferencesHelpe
     var doubleTapAnimDuration = 500
         private set
 
+    var landscapeMode = 1
+        private set
+
     init {
         preferences.readWithTapping()
             .register({ tappingEnabled = it })
@@ -70,6 +73,9 @@ class PagerConfig(private val viewer: PagerViewer, preferences: PreferencesHelpe
 
         preferences.readWithVolumeKeysInverted()
             .register({ volumeKeysInverted = it })
+
+        preferences.landscapeMode()
+                .register({landscapeMode = it})
     }
 
     fun unsubscribe() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
@@ -19,6 +19,12 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
      */
     var items: List<Any> = emptyList()
         private set
+    /**
+     *
+     */
+    var twoPageSpreadMode = true
+
+    val config = viewer.config
 
     /**
      * Updates this adapter with the given [chapters]. It handles setting a few pages of the
@@ -96,6 +102,20 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
             }
         }
         return PagerAdapter.POSITION_NONE
+    }
+
+    override fun getPageWidth(position: Int):Float{
+
+
+
+        if(twoPageSpreadMode && config.landscapeMode == 2)
+            return 0.5f
+        else
+            return 1.0f
+    }
+
+    fun setBoolS(bool: Boolean){
+        twoPageSpreadMode = bool
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
@@ -48,6 +48,14 @@ class SettingsReaderController : SettingsController() {
             summary = "%s"
         }
         intListPreference {
+            key = Keys.doublePageLandscape
+            titleRes = R.string.landscape_mode
+            entriesRes = arrayOf(R.string.landscape_one, R.string.landscape_two)
+            entryValues = arrayOf("1", "2")
+            defaultValue = "1"
+            summary = "%s"
+        }
+        intListPreference {
             key = Keys.readerTheme
             titleRes = R.string.pref_reader_theme
             entriesRes = arrayOf(R.string.white_background, R.string.black_background)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,6 +230,9 @@
     <string name="color_filter_g_value">G</string>
     <string name="color_filter_b_value">B</string>
     <string name="color_filter_a_value">A</string>
+    <string name="landscape_two">Two Pages</string>
+    <string name="landscape_one">One Page</string>
+    <string name="landscape_mode">Landscape Mode</string>
 
 
       <!-- Downloads section -->


### PR DESCRIPTION
This adds a setting to display two pages on the screen in landscape mode. When displaying two pages, tapping to turn pages "flips" forward two pages instead of one. Additionally when turning, the application will check for two-page spreads (two pages in one page according to the source). If a two page spread is detected on the next page it will flip forward one page to the two-page spread and set the application back to displaying one-page per screen. If a two-page spread is detected on the next-next page the application will try to "align" the page flipping and only advance one page instead of two.

This is my first pull request and work with Android in general and am open to feedback!