### PR TITLE
fixes the androidx prefererences icon spacing issue

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/PreferenceDSL.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/PreferenceDSL.kt
@@ -58,11 +58,17 @@ fun initDialog(dialogPreference: DialogPreference) {
 }
 
 inline fun <P : Preference> PreferenceGroup.initThenAdd(p: P, block: P.() -> Unit): P {
-    return p.apply { block(); addPreference(this); }
+    return p.apply {
+        block()
+        this.isIconSpaceReserved  = false
+        addPreference(this) }
 }
 
 inline fun <P : Preference> PreferenceGroup.addThenInit(p: P, block: P.() -> Unit): P {
-    return p.apply { addPreference(this); block() }
+    return p.apply {
+        this.isIconSpaceReserved  = false
+        addPreference(this)
+        block() }
 }
 
 inline fun Preference.onClick(crossinline block: () -> Unit) {


### PR DESCRIPTION
Once androidx update has been made this will fix the current issue in dev where the settings are indented