### PR TITLE
Improvements to EPUB support.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/storage/EpubFile.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/storage/EpubFile.kt
@@ -101,14 +101,12 @@ class EpubFile(file: File) : Closeable {
             val document = zip.getInputStream(entry).use { Jsoup.parse(it, null, "") }
             val imageBasePath = getParentDirectory(entryPath)
 
-            val imgs = document.getElementsByTag("img")
-            imgs.forEach {
-                result.add(resolveZipPath(imageBasePath, it.attr("src")))
-            }
-
-            val images = document.getElementsByTag("image")
-            images.forEach {
-                result.add(resolveZipPath(imageBasePath, it.attr("xlink:href")))
+            document.allElements.forEach {
+                if (it.tagName() == "img") {
+                    result.add(resolveZipPath(imageBasePath, it.attr("src")))
+                } else if (it.tagName() == "image") {
+                    result.add(resolveZipPath(imageBasePath, it.attr("xlink:href")))
+                }
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/storage/EpubFile.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/storage/EpubFile.kt
@@ -107,8 +107,17 @@ class EpubFile(file: File) : Closeable {
             val entry = zip.getEntry(entryPath)
             val document = zip.getInputStream(entry).use { Jsoup.parse(it, null, "") }
             val imageBasePath = getParentDirectory(entryPath, pathSeparator)
-            document.getElementsByTag("img").mapNotNull {
-                resolveZipPath(imageBasePath, it.attr("src"), pathSeparator)
+
+            val imgs = document.getElementsByTag("img")
+            if(imgs.isNotEmpty()) {
+                imgs.mapNotNull {
+                    resolveZipPath(imageBasePath, it.attr("src"), pathSeparator)
+                }
+            } else {
+                val images = document.getElementsByTag("image")
+                images.mapNotNull {
+                    resolveZipPath(imageBasePath, it.attr("xlink:href"), pathSeparator)
+                }
             }
         }.flatten()
     }


### PR DESCRIPTION
Fixes two problems I encountered trying to view local manga EPUBs in Tachiyomi:
* Image tags using relative paths were not resolved correctly.
* "META-INF/container.xml" couldn't be located in some EPUBs that used "\\" as a path separator.