### PR TITLE
adjust so downloader doesnt autostart when queue was paused

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -199,7 +199,7 @@ class Downloader(
      */
     fun queueChapters(manga: Manga, chapters: List<Chapter>, autoStart: Boolean) = launchUI {
         val source = sourceManager.get(manga.source) as? HttpSource ?: return@launchUI
-
+        val wasEmpty = queue.isEmpty()
         // Called in background thread, the operation can be slow with SAF.
         val chaptersWithoutDir = async {
             val mangaDir = provider.findMangaDir(manga, source)
@@ -232,7 +232,7 @@ class Downloader(
             }
 
             // Start downloader if needed
-            if (autoStart) {
+            if (autoStart && wasEmpty) {
                 DownloadService.start(this@Downloader.context)
             }
         }


### PR DESCRIPTION
fixes #2411

Chapters only autostart if the queue was empty when adding new chapters to it.  This way downloads still autostart when nothing is downloading, and don't autostart when queue was purposely paused