### PR TITLE
Use black background for AMOLED theme cards, dialogs

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -40,7 +40,6 @@
     <color name="appBarDark">@color/md_grey_900</color>
     <color name="backgroundDark">@color/colorDarkPrimaryDark</color>
     <color name="dialogDark">@color/colorDarkPrimary</color>
-    <color name="dialog_amoled">@color/colorDarkPrimaryDark</color>
 
     <color name="selectorColorDark">@color/md_blue_A200_50</color>
     <color name="iconColorDark">@color/md_white_1000_54</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -32,6 +32,10 @@
         <item name="colorAccent">@color/colorAccentDark</item>
     </style>
 
+    <style name="Theme.AlertDialog.Amoled" parent="Theme.AlertDialog.Dark">
+        <item name="android:background">@color/colorAmoledPrimary</item>
+    </style>
+
     <!--==============-->
     <!--NavigationView-->
     <!--==============-->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -113,10 +113,14 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
 
+        <!-- Themes -->
+        <item name="md_background_color">@color/colorAmoledPrimary</item>
+        <item name="alertDialogTheme">@style/Theme.AlertDialog.Amoled</item>
+
         <!-- Custom Attributes-->
         <item name="selectable_list_drawable">@drawable/list_item_selector_amoled</item>
         <item name="selectable_library_drawable">@drawable/library_item_selector_amoled</item>
-        <item name="background_card">@color/dialog_amoled</item>
+        <item name="background_card">@color/colorAmoledPrimary</item>
     </style>
 
     <style name="Theme.Tachiyomi.Amoled" parent="Theme.Base.Amoled">


### PR DESCRIPTION
Closes #1955 and #2473.

Makes it a bit hard to tell what a card or dialog's borders are though.