### PR TITLE
Improve Loading Speed When Skipping Pages in a Chapter

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -17,6 +17,7 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.util.concurrent.PriorityBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.min
 
 /**
  * Loader used to load chapters from an online source.
@@ -37,18 +38,24 @@ class HttpPageLoader(
      */
     private val subscriptions = CompositeSubscription()
 
+    private val preloadSize = 4
+
     init {
-        subscriptions += Observable.defer { Observable.just(queue.take().page) }
-            .filter { it.status == Page.QUEUE }
-            .concatMap { source.fetchImageFromCacheThenNet(it) }
-            .repeat()
-            .subscribeOn(Schedulers.io())
-            .subscribe({
-            }, { error ->
-                if (error !is InterruptedException) {
-                    Timber.e(error)
+        subscriptions += Observable.defer { Observable.just(queue.take()) }
+                .map {
+                    it.taken = true
+                    it.page
                 }
-            })
+                .filter { it.status == Page.QUEUE }
+                .concatMap { source.fetchImageFromCacheThenNet(it) }
+                .repeat()
+                .subscribeOn(Schedulers.io())
+                .subscribe({
+                }, { error ->
+                    if (error !is InterruptedException) {
+                        Timber.e(error)
+                    }
+                })
     }
 
     /**
@@ -80,13 +87,13 @@ class HttpPageLoader(
      */
     override fun getPages(): Observable<List<ReaderPage>> {
         return chapterCache
-            .getPageListFromCache(chapter.chapter)
-            .onErrorResumeNext { source.fetchPageList(chapter.chapter) }
-            .map { pages ->
-                pages.mapIndexed { index, page -> // Don't trust sources and use our own indexing
-                    ReaderPage(index, page.url, page.imageUrl)
+                .getPageListFromCache(chapter.chapter)
+                .onErrorResumeNext { source.fetchPageList(chapter.chapter) }
+                .map { pages ->
+                    pages.mapIndexed { index, page -> // Don't trust sources and use our own indexing
+                        ReaderPage(index, page.url, page.imageUrl)
+                    }
                 }
-            }
     }
 
     /**
@@ -110,29 +117,41 @@ class HttpPageLoader(
             val statusSubject = SerializedSubject(PublishSubject.create<Int>())
             page.setStatusSubject(statusSubject)
 
+            val queuedPages = mutableListOf<PriorityPage>()
             if (page.status == Page.QUEUE) {
-                queue.offer(PriorityPage(page, 1))
+                queuedPages += PriorityPage(page, 1).also { queue.offer(it) }
             }
-
-            preloadNextPages(page, 4)
+            queuedPages += preloadNextPages(page, preloadSize)
 
             statusSubject.startWith(page.status)
+                    .doOnUnsubscribe {
+                        queuedPages.forEach {
+                            if (!it.taken) {
+                                queue.remove(it)
+                            }
+                        }
+                    }
         }
+                .subscribeOn(Schedulers.io())
+                .unsubscribeOn(Schedulers.io())
     }
 
     /**
      * Preloads the given [amount] of pages after the [currentPage] with a lower priority.
+     * @return a list of [PriorityPage] that were added to the [queue]
      */
-    private fun preloadNextPages(currentPage: ReaderPage, amount: Int) {
+    private fun preloadNextPages(currentPage: ReaderPage, amount: Int): List<PriorityPage> {
         val pageIndex = currentPage.index
-        val pages = currentPage.chapter.pages ?: return
-        if (pageIndex == pages.lastIndex) return
-        val nextPages = pages.subList(pageIndex + 1, Math.min(pageIndex + 1 + amount, pages.size))
-        for (nextPage in nextPages) {
-            if (nextPage.status == Page.QUEUE) {
-                queue.offer(PriorityPage(nextPage, 0))
-            }
-        }
+        val pages = currentPage.chapter.pages ?: return emptyList()
+        if (pageIndex == pages.lastIndex) return emptyList()
+
+        return pages
+                .subList(pageIndex + 1, min(pageIndex + 1 + amount, pages.size))
+                .mapNotNull {
+                    if (it.status == Page.QUEUE) {
+                        PriorityPage(it, 0).apply { queue.offer(this) }
+                    } else null
+                }
     }
 
     /**
@@ -148,10 +167,13 @@ class HttpPageLoader(
     /**
      * Data class used to keep ordering of pages in order to maintain priority.
      */
-    private data class PriorityPage(
+    private class PriorityPage(
             val page: ReaderPage,
             val priority: Int
     ): Comparable<PriorityPage> {
+
+        @Volatile
+        var taken = false
 
         companion object {
             private val idGenerator = AtomicInteger()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -41,11 +41,7 @@ class HttpPageLoader(
     private val preloadSize = 4
 
     init {
-        subscriptions += Observable.defer { Observable.just(queue.take()) }
-                .map {
-                    it.taken = true
-                    it.page
-                }
+        subscriptions += Observable.defer { Observable.just(queue.take().page) }
                 .filter { it.status == Page.QUEUE }
                 .concatMap { source.fetchImageFromCacheThenNet(it) }
                 .repeat()
@@ -126,7 +122,7 @@ class HttpPageLoader(
             statusSubject.startWith(page.status)
                     .doOnUnsubscribe {
                         queuedPages.forEach {
-                            if (!it.taken) {
+                            if (it.page.status == Page.QUEUE) {
                                 queue.remove(it)
                             }
                         }
@@ -171,9 +167,6 @@ class HttpPageLoader(
             val page: ReaderPage,
             val priority: Int
     ): Comparable<PriorityPage> {
-
-        @Volatile
-        var taken = false
 
         companion object {
             private val idGenerator = AtomicInteger()


### PR DESCRIPTION
resolves #2386 

cancel queued loads when the page that requested the loads is destroyed