### PR TITLE
Remove repository for Conductor snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ allprojects {
     repositories {
         google()
         maven { url "https://www.jitpack.io" }
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         jcenter()
     }
 }


### PR DESCRIPTION
Was originally added in 5a3e30b30ac1290a5985441ad83ae10c80e0e1ce but is no longer needed.