### PR TITLE
CloudflareInterceptor Update / Bypass

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/network/CloudflareInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/CloudflareInterceptor.kt
@@ -54,7 +54,7 @@ class CloudflareInterceptor(private val context: Context) : Interceptor {
     }
 
     private fun isChallengeSolutionUrl(url: String): Boolean {
-        return "chk_jschl" in url
+        return true //"chk_jschl" in url
     }
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -136,7 +136,7 @@ class CloudflareInterceptor(private val context: Context) : Interceptor {
             webView?.destroy()
         }
 
-        val solution = solutionUrl ?: throw Exception("Challenge not found")
+        val solution = solutionUrl ?: origRequestUrl//throw Exception("Challenge not found")
 
         return Request.Builder().get()
             .url(solution)


### PR DESCRIPTION
Request for comments and review:

After staring at the code for who knows how long, I determined that the original check for the CF interceptor comes down to shouldOverrideUrlLoading 

Cloudflare 'I'm under attack' check utilizes a POST method to validate itself. As per the [developer reference:](https://developer.android.com/reference/android/webkit/WebViewClient.html#shouldOverrideUrlLoading(android.webkit.WebView,%20android.webkit.WebResourceRequest))
> Note: This method is not called for POST requests. 

The proposed change bypasses the challenge solution url check because webview isn't able to intercept a POST request. The 12 seconds should allow for the challenge to load and the post to go though via webview before the app proceeds and loads the manga catalog again. 

MangaFree is one I identified to take longer to load but still should be fine after hitting retry. 