### PR TITLE
fix bangumi track will override record to 0 after every track search(bind)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/Bangumi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/Bangumi.kt
@@ -41,7 +41,7 @@ class Bangumi(private val context: Context, id: Int) : TrackService(id) {
             track.library_id = remoteTrack.library_id
             track.status = remoteTrack.status
             track.last_chapter_read = remoteTrack.last_chapter_read
-            update(track)
+            refresh(track)
           } else {
             // Set default fields if it's not found in the list
             track.score = DEFAULT_SCORE.toFloat()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
@@ -59,12 +59,12 @@ class BangumiApi(private val client: OkHttpClient, interceptor: BangumiIntercept
       .url("$apiUrl/collection/${track.media_id}/update")
       .post(sbody)
       .build()
-    return authClient.newCall(request)
+    return authClient.newCall(srequest)
       .asObservableSuccess()
       .map {
         track
       }.flatMap {
-        authClient.newCall(srequest)
+        authClient.newCall(request)
           .asObservableSuccess()
           .map {
             track


### PR DESCRIPTION
bangumi track will override record to 0   every track search(bind)
this update() should not be here

and

the update status api must be called before update chapter api
Need update status to "do"(reading) first , then you can update chapter num
Otherwise chapter num will uploaded next call