### PR TITLE
Some Misc Minor Reader Bug Fixes

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
@@ -20,6 +20,9 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
     var items: List<Any> = emptyList()
         private set
 
+    var nextTransition: ChapterTransition.Next? = null
+        private set
+
     /**
      * Updates this adapter with the given [chapters]. It handles setting a few pages of the
      * next/previous chapter to allow seamless transitions and inverting the pages if the viewer
@@ -46,7 +49,8 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
         }
 
         // Add next chapter transition and pages.
-        newItems.add(ChapterTransition.Next(chapters.currChapter, chapters.nextChapter))
+        nextTransition = ChapterTransition.Next(chapters.currChapter, chapters.nextChapter)
+                .also { newItems.add(it) }
         if (chapters.nextChapter != null) {
             // Add at most two pages, because this chapter will be selected before the user can
             // swap more pages.


### PR DESCRIPTION
 - fix preload on last page for R2L reader
 - page 3 bug: open a new chapter and scroll to page 3. Then use the scrollbar arrow to go to next chapter. The scrollbar page numbers don't update until you perform a page change.

![ezgif com-resize](https://user-images.githubusercontent.com/24946428/72218088-b3663400-34eb-11ea-85d0-75b48c598ef0.gif)
