### PR TITLE
Toolbar Menu Items Fix

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/controller/BaseController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/controller/BaseController.kt
@@ -85,10 +85,11 @@ abstract class BaseController(bundle: Bundle? = null) : RestoreViewOnCreateContr
     }
 
     /**
-     * Workaround for disappearing menu items when collapsing an expandable item like a SearchView.
+     * Workaround for buggy menu item layout after expanding/collapsing an expandable item like a SearchView.
      * This method should be removed when fixed upstream.
      * Issue link: https://issuetracker.google.com/issues/37657375
      */
+    var expandActionViewFromInteraction = false
     fun MenuItem.fixExpand(onExpand: ((MenuItem) -> Boolean)? = null, onCollapse: ((MenuItem) -> Boolean)? = null) {
         setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
             override fun onMenuItemActionExpand(item: MenuItem): Boolean {
@@ -101,6 +102,25 @@ abstract class BaseController(bundle: Bundle? = null) : RestoreViewOnCreateContr
                 return onCollapse?.invoke(item) ?: true
             }
         })
+
+        if (expandActionViewFromInteraction) {
+            expandActionViewFromInteraction = false
+            expandActionView()
+        }
+    }
+
+    /**
+     * Workaround for menu items not disappearing when expanding an expandable item like a SearchView.
+     * [expandActionViewFromInteraction] should be set to true in [onOptionsItemSelected] when the expandable item is selected
+     * This method should be called as part of [MenuItem.OnActionExpandListener.onMenuItemActionExpand]
+     */
+    fun invalidateMenuOnExpand(): Boolean {
+        return if (expandActionViewFromInteraction) {
+            activity?.invalidateOptionsMenu()
+            false
+        } else {
+            true
+        }
     }
 
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCatalogueController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/catalogue/browse/BrowseCatalogueController.kt
@@ -215,36 +215,38 @@ open class BrowseCatalogueController(bundle: Bundle) :
         inflater.inflate(R.menu.catalogue_list, menu)
 
         // Initialize search menu
-        menu.findItem(R.id.action_search).apply {
-            val searchView = actionView as SearchView
+        val searchItem = menu.findItem(R.id.action_search)
+        val searchView = searchItem.actionView as SearchView
 
-            val query = presenter.query
-            if (!query.isBlank()) {
-                expandActionView()
-                searchView.setQuery(query, true)
-                searchView.clearFocus()
-            }
-
-            val searchEventsObservable = searchView.queryTextChangeEvents()
-                    .skip(1)
-                    .filter { router.backstack.lastOrNull()?.controller() == this@BrowseCatalogueController }
-                    .share()
-            val writingObservable = searchEventsObservable
-                    .filter { !it.isSubmitted }
-                    .debounce(1250, TimeUnit.MILLISECONDS, AndroidSchedulers.mainThread())
-            val submitObservable = searchEventsObservable
-                    .filter { it.isSubmitted }
-
-            searchViewSubscription?.unsubscribe()
-            searchViewSubscription = Observable.merge(writingObservable, submitObservable)
-                    .map { it.queryText().toString() }
-                    .subscribeUntilDestroy { searchWithQuery(it) }
-
-            fixExpand(onCollapse = {
-                searchWithQuery("")
-                true
-            })
+        val query = presenter.query
+        if (!query.isBlank()) {
+            searchItem.expandActionView()
+            searchView.setQuery(query, true)
+            searchView.clearFocus()
         }
+
+        val searchEventsObservable = searchView.queryTextChangeEvents()
+                .skip(1)
+                .filter { router.backstack.lastOrNull()?.controller() == this@BrowseCatalogueController }
+                .share()
+        val writingObservable = searchEventsObservable
+                .filter { !it.isSubmitted }
+                .debounce(1250, TimeUnit.MILLISECONDS, AndroidSchedulers.mainThread())
+        val submitObservable = searchEventsObservable
+                .filter { it.isSubmitted }
+
+        searchViewSubscription?.unsubscribe()
+        searchViewSubscription = Observable.merge(writingObservable, submitObservable)
+                .map { it.queryText().toString() }
+                .subscribeUntilDestroy { searchWithQuery(it) }
+
+        searchItem.fixExpand(
+                onExpand = { invalidateMenuOnExpand() },
+                onCollapse = {
+                    searchWithQuery("")
+                    true
+                }
+        )
 
         // Setup filters button
         menu.findItem(R.id.action_set_filter).apply {
@@ -278,6 +280,7 @@ open class BrowseCatalogueController(bundle: Bundle) :
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
+            R.id.action_search -> expandActionViewFromInteraction = true
             R.id.action_display_mode -> swapDisplayMode()
             R.id.action_set_filter -> navView?.let { activity?.drawer?.openDrawer(GravityCompat.END) }
             R.id.action_open_in_browser -> openInBrowser()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionController.kt
@@ -80,6 +80,7 @@ open class ExtensionController : NucleusController<ExtensionPresenter>(),
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
+            R.id.action_search -> expandActionViewFromInteraction = true
             R.id.action_settings -> {
                 router.pushController((RouterTransaction.with(ExtensionFilterController()))
                         .popChangeHandler(SettingsExtensionsFadeChangeHandler())
@@ -137,7 +138,7 @@ open class ExtensionController : NucleusController<ExtensionPresenter>(),
             }
 
         // Fixes problem with the overflow icon showing up in lieu of search
-        searchItem.fixExpand()
+        searchItem.fixExpand(onExpand = { invalidateMenuOnExpand() })
     }
 
     override fun onItemClick(view: View, position: Int): Boolean {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -321,7 +321,7 @@ class LibraryController(
         val searchItem = menu.findItem(R.id.action_search)
         val searchView = searchItem.actionView as SearchView
 
-        if (!query.isEmpty()) {
+        if (query.isNotEmpty()) {
             searchItem.expandActionView()
             searchView.setQuery(query, true)
             searchView.clearFocus()
@@ -339,7 +339,7 @@ class LibraryController(
                     searchRelay.call(query)
                 }
 
-        searchItem.fixExpand()
+        searchItem.fixExpand(onExpand = { invalidateMenuOnExpand() })
     }
 
     override fun onPrepareOptionsMenu(menu: Menu) {
@@ -354,6 +354,7 @@ class LibraryController(
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
+            R.id.action_search -> expandActionViewFromInteraction = true
             R.id.action_filter -> {
                 navView?.let { activity?.drawer?.openDrawer(GravityCompat.END) }
             }


### PR DESCRIPTION
tl;dr: Toolbar is hilariously broken and Idk why I'm even trying to fix this.

Basically it seems like expanding/collapse an actionView after the toolbar is already finished laying out its items (e.g. from user interaction) doesn't trigger a re-layout of its items. 
That's why in the before gif, the filter icon is both shown and in the overflow at the same time. But when navigating back to the screen (or rotating the screen), since the actionView is already expanded (in onCreateOptionsMenu) before the layout, the filter icon disappears properly.

So just invalidate the menu if opened by user and force a new layout.

Before:
![ezgif com-resize(2)](https://user-images.githubusercontent.com/24946428/72391522-33ee8580-36e2-11ea-9a41-bd97c8632798.gif)

After:
![ezgif com-resize(1)](https://user-images.githubusercontent.com/24946428/72391521-33ee8580-36e2-11ea-9f3c-1bbdf4ffef77.gif)
