### PR TITLE
Bug/2513 edit text preference crash

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionDetailsController.kt
@@ -42,7 +42,9 @@ class ExtensionDetailsController(bundle: Bundle? = null) :
     })
 
     override fun inflateView(inflater: LayoutInflater, container: ViewGroup): View {
-        return inflater.inflate(R.layout.extension_detail_controller, container, false)
+        val themedInflater = inflater.cloneInContext(getPreferenceThemeContext())
+
+        return themedInflater.inflate(R.layout.extension_detail_controller, container, false)
     }
 
     override fun createPresenter(): ExtensionDetailsPresenter {
@@ -142,6 +144,7 @@ class ExtensionDetailsController(bundle: Bundle? = null) :
             // Reparent the preferences
             while (newScreen.preferenceCount != 0) {
                 val pref = newScreen.getPreference(0)
+                pref.isIconSpaceReserved = false
                 pref.preferenceDataStore = dataStore
                 pref.order = Int.MAX_VALUE // reset to default order
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionDetailsController.kt
@@ -77,7 +77,7 @@ class ExtensionDetailsController(bundle: Bundle? = null) :
         val manager = PreferenceManager(themedContext)
         manager.preferenceDataStore = EmptyPreferenceDataStore()
         manager.onDisplayPreferenceDialogListener = this
-        val screen = manager.createPreferenceScreen(context)
+        val screen = manager.createPreferenceScreen(themedContext)
         preferenceScreen = screen
 
         val multiSource = extension.sources.size > 1

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -27,7 +27,7 @@
         <!-- Themes -->
         <item name="windowActionModeOverlay">true</item>
         <item name="actionBarTheme">@style/Theme.ActionBar.Light</item>
-        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
         <item name="alertDialogTheme">@style/Theme.AlertDialog.Light</item>
 
 
@@ -74,7 +74,7 @@
         <item name="windowActionModeOverlay">true</item>
         <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat</item>
-        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
         <item name="md_background_color">@color/dialogDark</item>
         <item name="alertDialogTheme">@style/Theme.AlertDialog.Dark</item>
 


### PR DESCRIPTION
Fixes #2513 

PreferenceScreen needs to be created using the themedContext, otherwise it's not able to resolve to the proper editTextPreference layout in the preference library and instead defaults to a layout bundled with the sdk (which for some reason doesn't have an edit text in it, causing the crash).

Inflater change is based on PreferenceFragmentCompat (and by extension PreferenceController in the conductor-support-preference library). This fixes the PreferenceCategory title being super tiny.

v14 preference themes are deprecated per [release notes](https://developer.android.com/jetpack/androidx/releases/archive/androidx#1.0.0rc01)