### PR TITLE
Do not suppress a type system error

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/presenter/NucleusConductorDelegate.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/presenter/NucleusConductorDelegate.kt
@@ -29,7 +29,9 @@ class NucleusConductorDelegate<P : Presenter<*>>(private val factory: PresenterF
         bundle = presenterState
     }
 
-    @Suppress("TYPE_MISMATCH")
+    @Suppress("UNCHECKED_CAST")
+    private fun <View> Presenter<View>.takeView(view: Any) = takeView(view as View)
+
     fun onTakeView(view: Any) {
         presenter?.takeView(view)
     }


### PR DESCRIPTION
This code was sort of fine when it used raw Java types, but the Kotlin equivalent technically calls a method that takes a Nothing-typed argument with a value that is not of type Nothing. Whether that works depends on how lenient kotlinc is about inserting casts in bytecode.

The solution is to give the unknown type represented by a star an explicit name by capturing it in a type variable, then cast to that type instead of Nothing. This is guaranteed to be an unchecked, but valid, cast.