### PR TITLE
Manga Info Page UI Update

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -223,7 +223,7 @@ class MangaInfoController : NucleusController<MangaInfoPresenter>(),
                     .centerCrop()
                     .into(manga_cover)
 
-            if (backdrop != null) {
+            backdrop?.post {
                 GlideApp.with(view.context)
                         .load(manga)
                         .diskCacheStrategy(DiskCacheStrategy.RESOURCE)

--- a/app/src/main/res/layout-land/manga_info_controller.xml
+++ b/app/src/main/res/layout-land/manga_info_controller.xml
@@ -9,11 +9,8 @@
     android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        xmlns:android="http://schemas.android.com/apk/res/android">
+        android:layout_height="match_parent">
 
         <ImageView
             android:id="@+id/manga_cover"
@@ -43,10 +40,8 @@
             android:id="@+id/info_scrollview"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
+            android:layout_margin="16dp"
+            android:requiresFadingEdge="vertical"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@+id/manga_cover"
@@ -57,19 +52,14 @@
                 android:layout_height="match_parent">
 
                 <TextView
-                    android:text="@string/manga_info_full_title_label"
                     android:id="@+id/manga_full_title"
                     style="@style/TextAppearance.Medium.Title"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:maxLines="2"
+                    android:text="@string/manga_info_full_title_label"
                     android:textIsSelectable="false"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:autoSizeTextType="uniform"
-                    app:autoSizeMinTextSize="12sp"
-                    app:autoSizeMaxTextSize="20sp"
-                    app:autoSizeStepGranularity="2sp"/>
+                    app:layout_constraintStart_toStartOf="parent"/>
 
                 <TextView
                     android:id="@+id/manga_author_label"

--- a/app/src/main/res/layout/manga_info_controller.xml
+++ b/app/src/main/res/layout/manga_info_controller.xml
@@ -8,292 +8,283 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:requiresFadingEdge="vertical">
 
-        <View
-            android:id="@+id/guideline"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginTop="16dp"
-            app:layout_constraintTop_toBottomOf="@+id/manga_cover"/>
-
-        <androidx.constraintlayout.widget.Guideline
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/guideline2"
-            android:orientation="vertical"
-            app:layout_constraintGuide_percent="0.38"/>
-
-        <ImageView
-            android:id="@+id/backdrop"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:alpha="0.2"
-            tools:background="@color/material_grey_700"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/guideline"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"/>
-
-        <ImageView
-            android:id="@+id/manga_cover"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:contentDescription="@string/description_cover"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/guideline2"
-            app:layout_constraintDimensionRatio="h,2:3"
-            tools:background="@color/material_grey_700"/>
-
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/fab_favorite"
-            style="@style/Theme.Widget.FAB"
-            app:srcCompat="@drawable/ic_add_to_library_24dp"
-            android:layout_marginTop="0dp"
-            android:layout_marginBottom="0dp"
-            android:layout_marginEnd="8dp"
-            app:layout_constraintTop_toBottomOf="@+id/guideline"
-            app:layout_constraintBottom_toTopOf="@+id/guideline"
-            app:layout_constraintEnd_toEndOf="parent"/>
-
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/info_scrollview"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginBottom="16dp"
-            android:layout_marginStart="0dp"
-            android:layout_marginEnd="16dp"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/guideline"
-            app:layout_constraintStart_toStartOf="@+id/guideline2"
-            app:layout_constraintEnd_toEndOf="parent">
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
-
-                <TextView
-                    android:text="@string/manga_info_full_title_label"
-                    android:id="@+id/manga_full_title"
-                    style="@style/TextAppearance.Medium.Title"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:maxLines="2"
-                    android:textIsSelectable="false"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:autoSizeTextType="uniform"
-                    app:autoSizeMinTextSize="12sp"
-                    app:autoSizeMaxTextSize="20sp"
-                    app:autoSizeStepGranularity="2sp"/>
-
-                <TextView
-                    android:id="@+id/manga_author_label"
-                    style="@style/TextAppearance.Medium.Body2"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/manga_info_author_label"
-                    android:textIsSelectable="false"
-
-                    app:layout_constraintTop_toBottomOf="@+id/manga_full_title"
-                    app:layout_constraintStart_toStartOf="parent"/>
-
-                <TextView
-                    android:id="@+id/manga_author"
-                    style="@style/TextAppearance.Regular.Body1.Secondary"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:textIsSelectable="false"
-                    app:layout_constraintBaseline_toBaselineOf="@+id/manga_author_label"
-                    app:layout_constraintStart_toEndOf="@+id/manga_author_label"
-                    app:layout_constraintEnd_toEndOf="parent"/>
-
-                <TextView
-                    android:id="@+id/manga_artist_label"
-                    style="@style/TextAppearance.Medium.Body2"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/manga_info_artist_label"
-                    android:textIsSelectable="false"
-                    app:layout_constraintTop_toBottomOf="@+id/manga_author_label"
-                    app:layout_constraintStart_toStartOf="parent"/>
-
-                <TextView
-                    android:id="@+id/manga_artist"
-                    style="@style/TextAppearance.Regular.Body1.Secondary"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:textIsSelectable="false"
-                    app:layout_constraintBaseline_toBaselineOf="@+id/manga_artist_label"
-                    app:layout_constraintStart_toEndOf="@+id/manga_artist_label"
-                    app:layout_constraintEnd_toEndOf="parent"/>
-
-                <TextView
-                    android:id="@+id/manga_chapters_label"
-                    style="@style/TextAppearance.Medium.Body2"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/manga_info_last_chapter_label"
-                    android:textIsSelectable="false"
-                    app:layout_constraintTop_toBottomOf="@+id/manga_artist_label"
-                    app:layout_constraintStart_toStartOf="parent"/>
-
-                <TextView
-                    android:id="@+id/manga_chapters"
-                    style="@style/TextAppearance.Regular.Body1.Secondary"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:textIsSelectable="false"
-                    app:layout_constraintBaseline_toBaselineOf="@+id/manga_chapters_label"
-                    app:layout_constraintStart_toEndOf="@+id/manga_chapters_label"
-                    app:layout_constraintEnd_toEndOf="parent"/>
-
-                <TextView
-                    android:id="@+id/manga_last_update_label"
-                    style="@style/TextAppearance.Medium.Body2"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/manga_info_latest_data_label"
-                    android:textIsSelectable="false"
-                    app:layout_constraintTop_toBottomOf="@+id/manga_chapters_label"
-                    app:layout_constraintStart_toStartOf="parent"/>
-
-                <TextView
-                    android:id="@+id/manga_last_update"
-                    style="@style/TextAppearance.Regular.Body1.Secondary"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:textIsSelectable="false"
-                    app:layout_constraintBaseline_toBaselineOf="@+id/manga_last_update_label"
-                    app:layout_constraintStart_toEndOf="@+id/manga_last_update_label"
-                    app:layout_constraintEnd_toEndOf="parent"/>
-
-                <TextView
-                    android:id="@+id/manga_status_label"
-                    style="@style/TextAppearance.Medium.Body2"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/manga_info_status_label"
-                    android:textIsSelectable="false"
-                    app:layout_constraintTop_toBottomOf="@+id/manga_last_update_label"
-                    app:layout_constraintStart_toStartOf="parent"/>
-
-                <TextView
-                    android:id="@+id/manga_status"
-                    style="@style/TextAppearance.Regular.Body1.Secondary"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:textIsSelectable="false"
-                    app:layout_constraintBaseline_toBaselineOf="@+id/manga_status_label"
-                    app:layout_constraintStart_toEndOf="@+id/manga_status_label"
-                    app:layout_constraintEnd_toEndOf="parent"/>
-
-                <TextView
-                    android:id="@+id/manga_source_label"
-                    style="@style/TextAppearance.Medium.Body2"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/manga_info_source_label"
-                    android:textIsSelectable="false"
-                    app:layout_constraintTop_toBottomOf="@+id/manga_status_label"
-                    app:layout_constraintStart_toStartOf="parent"/>
-
-                <TextView
-                    android:id="@+id/manga_source"
-                    style="@style/TextAppearance.Regular.Body1.Secondary"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:textIsSelectable="false"
-                    app:layout_constraintBaseline_toBaselineOf="@+id/manga_source_label"
-                    app:layout_constraintStart_toEndOf="@+id/manga_source_label"
-                    app:layout_constraintEnd_toEndOf="parent"/>
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-        </androidx.core.widget.NestedScrollView>
-
-        <TextView
-            android:id="@+id/manga_summary_label"
-            style="@style/TextAppearance.Medium.Body2"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginTop="8dp"
-            android:text="@string/description"
-            app:layout_constraintTop_toBottomOf="@+id/guideline"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:textIsSelectable="false"/>
+            android:layout_height="match_parent">
 
-        <androidx.core.widget.NestedScrollView
-            android:id="@+id/description_scrollview"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constrainedHeight="true"
-            app:layout_constraintBottom_toTopOf="@id/manga_genres_tags"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/manga_summary_label"
-            app:layout_constraintVertical_bias="0.0"
-            app:layout_constraintVertical_chainStyle="packed">
+            <View
+                android:id="@+id/guideline"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="16dp"
+                app:layout_constraintTop_toBottomOf="@+id/manga_cover"
+                tools:ignore="MissingConstraints"/>
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guideline2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.38"/>
+
+            <ImageView
+                android:id="@+id/backdrop"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:alpha="0.2"
+                tools:background="@color/material_grey_700"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toTopOf="@+id/guideline"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent">
+            </ImageView>
 
             <TextView
-                android:id="@+id/manga_summary"
-                style="@style/TextAppearance.Regular.Body1.Secondary"
+                android:id="@+id/manga_full_title"
+                style="@style/TextAppearance.Medium.Title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:text="@string/manga_info_full_title_label"
+                android:textIsSelectable="false"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+            <ImageView
+                android:id="@+id/manga_cover"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:contentDescription="@string/description_cover"
+                app:layout_constraintTop_toBottomOf="@id/manga_full_title"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/guideline2"
+                app:layout_constraintDimensionRatio="h,2:3"
+                tools:background="@color/material_grey_700"/>
+
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fab_favorite"
+                style="@style/Theme.Widget.FAB"
+                app:srcCompat="@drawable/ic_add_to_library_24dp"
+                android:layout_marginTop="0dp"
+                android:layout_marginBottom="0dp"
+                android:layout_marginEnd="8dp"
+                app:layout_constraintTop_toBottomOf="@+id/guideline"
+                app:layout_constraintBottom_toTopOf="@+id/guideline"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+            <androidx.core.widget.NestedScrollView
+                android:id="@+id/info_scrollview"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="16dp"
+                android:layout_marginStart="0dp"
+                android:layout_marginEnd="16dp"
+                android:requiresFadingEdge="vertical"
+                app:layout_constraintTop_toBottomOf="@id/manga_full_title"
+                app:layout_constraintBottom_toTopOf="@+id/guideline"
+                app:layout_constraintStart_toStartOf="@+id/guideline2"
+                app:layout_constraintEnd_toEndOf="parent">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+
+                    <TextView
+                        android:id="@+id/manga_author_label"
+                        style="@style/TextAppearance.Medium.Body2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/manga_info_author_label"
+                        android:textIsSelectable="false"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/manga_author"
+                        style="@style/TextAppearance.Regular.Body1.Secondary"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textIsSelectable="false"
+                        app:layout_constraintBaseline_toBaselineOf="@+id/manga_author_label"
+                        app:layout_constraintStart_toEndOf="@+id/manga_author_label"
+                        app:layout_constraintEnd_toEndOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/manga_artist_label"
+                        style="@style/TextAppearance.Medium.Body2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/manga_info_artist_label"
+                        android:textIsSelectable="false"
+                        app:layout_constraintTop_toBottomOf="@+id/manga_author_label"
+                        app:layout_constraintStart_toStartOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/manga_artist"
+                        style="@style/TextAppearance.Regular.Body1.Secondary"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textIsSelectable="false"
+                        app:layout_constraintBaseline_toBaselineOf="@+id/manga_artist_label"
+                        app:layout_constraintStart_toEndOf="@+id/manga_artist_label"
+                        app:layout_constraintEnd_toEndOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/manga_chapters_label"
+                        style="@style/TextAppearance.Medium.Body2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/manga_info_last_chapter_label"
+                        android:textIsSelectable="false"
+                        app:layout_constraintTop_toBottomOf="@+id/manga_artist_label"
+                        app:layout_constraintStart_toStartOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/manga_chapters"
+                        style="@style/TextAppearance.Regular.Body1.Secondary"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textIsSelectable="false"
+                        app:layout_constraintBaseline_toBaselineOf="@+id/manga_chapters_label"
+                        app:layout_constraintStart_toEndOf="@+id/manga_chapters_label"
+                        app:layout_constraintEnd_toEndOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/manga_last_update_label"
+                        style="@style/TextAppearance.Medium.Body2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/manga_info_latest_data_label"
+                        android:textIsSelectable="false"
+                        app:layout_constraintTop_toBottomOf="@+id/manga_chapters_label"
+                        app:layout_constraintStart_toStartOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/manga_last_update"
+                        style="@style/TextAppearance.Regular.Body1.Secondary"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textIsSelectable="false"
+                        app:layout_constraintBaseline_toBaselineOf="@+id/manga_last_update_label"
+                        app:layout_constraintStart_toEndOf="@+id/manga_last_update_label"
+                        app:layout_constraintEnd_toEndOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/manga_status_label"
+                        style="@style/TextAppearance.Medium.Body2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/manga_info_status_label"
+                        android:textIsSelectable="false"
+                        app:layout_constraintTop_toBottomOf="@+id/manga_last_update_label"
+                        app:layout_constraintStart_toStartOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/manga_status"
+                        style="@style/TextAppearance.Regular.Body1.Secondary"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textIsSelectable="false"
+                        app:layout_constraintBaseline_toBaselineOf="@+id/manga_status_label"
+                        app:layout_constraintStart_toEndOf="@+id/manga_status_label"
+                        app:layout_constraintEnd_toEndOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/manga_source_label"
+                        style="@style/TextAppearance.Medium.Body2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/manga_info_source_label"
+                        android:textIsSelectable="false"
+                        app:layout_constraintTop_toBottomOf="@+id/manga_status_label"
+                        app:layout_constraintStart_toStartOf="parent"/>
+
+                    <TextView
+                        android:id="@+id/manga_source"
+                        style="@style/TextAppearance.Regular.Body1.Secondary"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textIsSelectable="false"
+                        app:layout_constraintBaseline_toBaselineOf="@+id/manga_source_label"
+                        app:layout_constraintStart_toEndOf="@+id/manga_source_label"
+                        app:layout_constraintEnd_toEndOf="parent"/>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </androidx.core.widget.NestedScrollView>
+
+            <TextView
+                android:id="@+id/manga_summary_label"
+                style="@style/TextAppearance.Medium.Body2"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
-                android:textIsSelectable="false" />
+                android:layout_marginTop="8dp"
+                android:text="@string/description"
+                android:textIsSelectable="false"
+                app:layout_constraintTop_toBottomOf="@+id/guideline"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"/>
 
-        </androidx.core.widget.NestedScrollView>
+            <TextView
+                android:id="@+id/manga_summary"
+                style="@style/TextAppearance.Regular.Body1.Secondary"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:textIsSelectable="false"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/manga_summary_label"/>
 
-        <me.gujun.android.taggroup.TagGroup
-            android:id="@+id/manga_genres_tags"
-            style="@style/TagGroup"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginBottom="8dp"
-            app:layout_constrainedHeight="true"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/description_scrollview"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:atg_borderStrokeWidth="1dp"
-            app:atg_backgroundColor="@android:color/transparent"
-            app:atg_borderColor="@color/md_blue_A400"
-            app:atg_textColor="@color/md_blue_A400" />
+            <me.gujun.android.taggroup.TagGroup
+                android:id="@+id/manga_genres_tags"
+                style="@style/TagGroup"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/manga_summary"
+                app:atg_borderStrokeWidth="1dp"
+                app:atg_backgroundColor="@android:color/transparent"
+                app:atg_borderColor="@color/md_blue_A400"
+                app:atg_textColor="@color/md_blue_A400"/>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
 
 </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
Fixes #1699 

Also relevant #1194. 

**Current**:
- Some titles are still too long to fit.
- Tiny font title looks bad imo.
- Autosize text sucks and never behaves consistently (case in point: note the extra space below the title that disappears after refresh). Also technically it's meant for fixed-sized containers, not `wrap_content` so really shouldn't have used it in the first place.

![ezgif com-resize](https://user-images.githubusercontent.com/24946428/73049963-154f6380-3e33-11ea-9ef5-326cbebf1d2c.gif)

**Changes**:
- Move title above the cover image to have it span the full screen width; remove autosize and max 2 lines.
- Allow the entire page to scroll and get rid of the description nested scroll.
- Add edge fade to the scroll views (pretty subtle but it comes for free so why not).

![ezgif com-resize(2)](https://user-images.githubusercontent.com/24946428/73050984-6d3b9980-3e36-11ea-9b5a-9cf51829064f.gif)





