### PR TITLE
Deep Link and Launch Mode Fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,12 +28,19 @@
         android:theme="@style/Theme.Tachiyomi">
         <activity
             android:name=".ui.main.MainActivity"
-            android:launchMode="singleTask"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!--suppress AndroidDomInspection -->
+            <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts"/>
+        </activity>
+        <activity
+            android:name=".ui.main.DeepLinkActivity"
+            android:launchMode="singleTask"
+            android:theme="@android:style/Theme.NoDisplay">
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH" />
                 <action android:name="com.google.android.gms.actions.SEARCH_ACTION"/>
@@ -44,8 +51,6 @@
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
             <meta-data android:name="android.app.searchable" android:resource="@xml/searchable"/>
-            <!--suppress AndroidDomInspection -->
-            <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts"/>
         </activity>
         <activity
             android:name=".ui.reader.ReaderActivity" />

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/DeepLinkActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/DeepLinkActivity.kt
@@ -1,0 +1,19 @@
+package eu.kanade.tachiyomi.ui.main
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+class DeepLinkActivity: Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        intent.apply {
+            flags = flags or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+            setClass(applicationContext, MainActivity::class.java)
+        }
+        startActivity(intent)
+        finish()
+    }
+}


### PR DESCRIPTION
Fixes #2054 hopefully without breaking deep linking again.

The idea is to simply redirect all deep links through an invisible activity. This provides full control of the  intent that actually reaches the MainActivity and lets us apply the appropriate flags to ensure it launches correctly, while avoiding the `singleTask` launch mode on MainActivity to fix #2054.

Scenarios tested on Android 9:
- [x] Mangadex deep link: no duplicate instances created
- [x] Google App and Google Assistant search
- [x] Library Update notifications
- [x] App shortcuts