### PR TITLE
Library View: Add latest chapter sorting and revert last updated sorting changes

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
@@ -113,6 +113,19 @@ interface MangaQueries : DbProvider {
                     .build())
             .prepare()
 
-    fun getTotalChapterManga() = db.get().listOfObjects(Manga::class.java)
-            .withQuery(RawQuery.builder().query(getTotalChapterMangaQuery()).observesTables(MangaTable.TABLE).build()).prepare();
+    fun getTotalChapterManga() = db.get()
+            .listOfObjects(Manga::class.java)
+            .withQuery(RawQuery.builder()
+                    .query(getTotalChapterMangaQuery())
+                    .observesTables(MangaTable.TABLE)
+                    .build())
+            .prepare()
+
+    fun getLatestChapterManga() = db.get()
+            .listOfObjects(Manga::class.java)
+            .withQuery(RawQuery.builder()
+                    .query(getLatestChapterMangaQuery())
+                    .observesTables(MangaTable.TABLE)
+                    .build())
+            .prepare()
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
@@ -102,6 +102,15 @@ fun getTotalChapterMangaQuery()= """
     ORDER by COUNT(*)
 """
 
+fun getLatestChapterMangaQuery()= """
+    SELECT ${Manga.TABLE}.*, MAX(${Chapter.TABLE}.${Chapter.COL_DATE_UPLOAD}) AS max
+    FROM ${Manga.TABLE}
+    JOIN ${Chapter.TABLE}
+    ON ${Manga.TABLE}.${Manga.COL_ID} = ${Chapter.TABLE}.${Chapter.COL_MANGA_ID}
+    GROUP BY ${Manga.TABLE}.${Manga.COL_ID}
+    ORDER by max DESC
+"""
+
 /**
  * Query to get the categories for a manga.
  */

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryNavigationView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryNavigationView.kt
@@ -117,7 +117,7 @@ class LibraryNavigationView @JvmOverloads constructor(context: Context, attrs: A
 
         private val source = Item.MultiSort(R.string.manga_info_source_label, this)
 
-        private val latestChapter = Item.MultiSort(R.string.manga_info_last_chapter_label, this)
+        private val latestChapter = Item.MultiSort(R.string.action_sort_latest_chapter, this)
 
         override val items = listOf(alphabetically, lastRead, lastUpdated, unread, total, source, latestChapter)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryNavigationView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryNavigationView.kt
@@ -117,7 +117,9 @@ class LibraryNavigationView @JvmOverloads constructor(context: Context, attrs: A
 
         private val source = Item.MultiSort(R.string.manga_info_source_label, this)
 
-        override val items = listOf(alphabetically, lastRead, lastUpdated, unread, total, source)
+        private val latestChapter = Item.MultiSort(R.string.manga_info_last_chapter_label, this)
+
+        override val items = listOf(alphabetically, lastRead, lastUpdated, unread, total, source, latestChapter)
 
         override val header = Item.Header(R.string.action_sort)
 
@@ -134,6 +136,7 @@ class LibraryNavigationView @JvmOverloads constructor(context: Context, attrs: A
             unread.state = if (sorting == LibrarySort.UNREAD) order else SORT_NONE
             total.state = if (sorting == LibrarySort.TOTAL) order else SORT_NONE
             source.state = if (sorting == LibrarySort.SOURCE) order else SORT_NONE
+            latestChapter.state = if (sorting == LibrarySort.LATEST_CHAPTER) order else SORT_NONE
         }
 
         override fun onItemClicked(item: Item) {
@@ -155,6 +158,7 @@ class LibraryNavigationView @JvmOverloads constructor(context: Context, attrs: A
                 unread -> LibrarySort.UNREAD
                 total -> LibrarySort.TOTAL
                 source -> LibrarySort.SOURCE
+                latestChapter -> LibrarySort.LATEST_CHAPTER
                 else -> throw Exception("Unknown sorting")
             })
             preferences.librarySortingAscending().set(if (item.state == SORT_ASC) true else false)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -185,6 +185,10 @@ class LibraryPresenter(
             var counter = 0
             db.getTotalChapterManga().executeAsBlocking().associate { it.id!! to counter++ }
         }
+        val latestChapterManga by lazy {
+            var counter = 0
+            db.getLatestChapterManga().executeAsBlocking().associate { it.id!! to counter++ }
+        }
 
         val sortFn: (LibraryItem, LibraryItem) -> Int = { i1, i2 ->
             when (sortingMode) {
@@ -206,6 +210,11 @@ class LibraryPresenter(
                     val source1Name = sourceManager.getOrStub(i1.manga.source).name
                     val source2Name = sourceManager.getOrStub(i2.manga.source).name
                     source1Name.compareTo(source2Name)
+                }
+                LibrarySort.LATEST_CHAPTER -> {
+                    val manga1latestChapter = latestChapterManga[i1.manga.id!!] ?: 0
+                    val manga2latestChapter = latestChapterManga[i2.manga.id!!] ?: 0
+                    manga1latestChapter.compareTo(manga2latestChapter)
                 }
                 else -> throw Exception("Unknown sorting mode")
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySort.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySort.kt
@@ -8,4 +8,5 @@ object LibrarySort {
     const val UNREAD = 3
     const val TOTAL = 4
     const val SOURCE = 5
+    const val LATEST_CHAPTER = 6
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
@@ -129,9 +129,8 @@ fun syncChaptersWithSource(db: DatabaseHelper,
         // Fix order in source.
         db.fixChaptersSourceOrder(sourceChapters).executeAsBlocking()
 
-        // Set manga's last update time to latest chapter's upload time if possible
-        val newestChapter = db.getChapters(manga).executeAsBlocking().maxBy { it.date_upload }
-        manga.last_update = newestChapter?.date_upload ?: manga.last_update
+        // Set this manga as updated since chapters were changed
+        manga.last_update = Date().time
         db.updateLastUpdated(manga).executeAsBlocking()
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="action_sort_total">Total chapters</string>
     <string name="action_sort_last_read">Last read</string>
     <string name="action_sort_last_updated">Last updated</string>
+    <string name="action_sort_latest_chapter">Latest chapter</string>
     <string name="action_search">Search</string>
     <string name="action_global_search">Global search</string>
     <string name="action_select_all">Select all</string>


### PR DESCRIPTION
Latest chapter is as it sounds
Last update is now any changes to the chapter list (addition, removal, rename, etc.; this is what the behavior was prior to the commits referenced in #2539)

Fixes #2539 