### PR TITLE
Change default theme to System Default

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -54,7 +54,7 @@ class PreferencesHelper(val context: Context) {
 
     fun clear() = prefs.edit().clear().apply()
 
-    fun themeMode() = rxPrefs.getString(Keys.themeMode, Values.THEME_MODE_LIGHT)
+    fun themeMode() = rxPrefs.getString(Keys.themeMode, Values.THEME_MODE_SYSTEM)
 
     fun themeDark() = prefs.getString(Keys.themeDark, Values.THEME_DARK_DEFAULT)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
@@ -71,7 +71,7 @@ class SettingsGeneralController : SettingsController() {
                         Values.THEME_MODE_LIGHT,
                         Values.THEME_MODE_DARK)
             }
-            defaultValue = Values.THEME_MODE_LIGHT
+            defaultValue = Values.THEME_MODE_SYSTEM
             summary = "%s"
 
             onChange {


### PR DESCRIPTION
_Hopefully this was the only string that dictated the default setting._

This is the recommended way of handling application theme defaults according to the Android Developers page about Dark themes.

> When running on Android 10 (API level 29) and higher, the recommended options are different, to allow the user to override the system default:
> 
> **Light**
> **Dark**
> **System default** (the recommended default option)
- https://developer.android.com/guide/topics/ui/look-and-feel/darktheme#changing_themes_in-app