### PR TITLE
Update changelog to be more current

### DIFF
--- a/app/src/main/res/raw/changelog_debug.xml
+++ b/app/src/main/res/raw/changelog_debug.xml
@@ -1,39 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<changelog bulletedList="false">
+<changelog bulletedList="true">
 
-    <changelogversion changeDate="" versionName="r1340">
-        <changelogtext>A new screen for managing extensions was added. If you previously installed extensions from FDroid,
-            you will have to uninstall all of them first (tap on the extension then uninstall), otherwise you won't be able
-            to update them due to signature mismatch. You won't lose anything in this process as the extensions themselves
-            don't store anything.
-        </changelogtext>
+    <changelogversion changeDate="Feb 28, 2020" versionName="r1781">
+        <changelogtext>Unused icon and LoginSource removed</changelogtext>
+        <changelogtext>Unlock string reworded</changelogtext>
+	<changelogtext>Changed check for system dark mode</changelogtext>
+	<changelogtext>Added ripple to menu icons</changelogtext>
+	<changelogtext>Top padding removed from more screen</changelogtext>
+	<changelogtext>Bottom Nav labels always shown</changelogtext>
+    </changelogversion>
+    
+    <changelogversion changeDate="Feb 26, 2020" versionName="r1771">
+        <changelogtext>Added description for secure screen setting</changelogtext>
+        <changelogtext>Linting Fixes</changelogtext>
+	<changelogtext>Migrated to bottom navigation</changelogtext>
+    </changelogversion>
+    
+    <changelogversion changeDate="Feb 24, 2020" versionName="r1764">
+        <changelogtext>New icons for update/history sections</changelogtext>
+        <changelogtext>Fix crash when loading invalid extensions</changelogtext>
     </changelogversion>
 
-    <changelogversion changeDate="" versionName="r959">
-        <changelogtext>The download manager has been rewritten and it's possible some of your downloads
-            aren't recognized anymore. You may have to check your downloads folder and manually delete those.
-        </changelogtext>
-        <changelogtext>You can now download to any folder in your SD card.</changelogtext>
-        <changelogtext>The download directory setting has been reset.</changelogtext>
+    <changelogversion changeDate="Feb 23, 2020" versionName="r1761">
+        <changelogtext>Crash reports setting moved to advanced</changelogtext>
+        <changelogtext>Refresh webtoon adapter on image property changed</changelogtext>
+	<changelogtext>Webtoon page padding now sets on page bind</changelogtext>
+	<changelogtext>Null file paths hidden when creating backups</changelogtext>
+	<changelogtext>Added Webtoon with Padding Viewer</changelogtext>
+	<changelogtext>"Clear" renamed to "Cancell All" in Download queue</changelogtext>
+	<changelogtext>Color filter moved behind reader toolbars</changelogtext>
     </changelogversion>
 
-    <changelogversion changeDate="" versionName="r857">
-        <changelogtext>[b]Important![/b] Delete after read has been updated.
-            This means the value has been reset set to disabled.
-            This can be changed in Settings > Downloads
-        </changelogtext>
+    <changelogversion changeDate="Feb 22, 2020" versionName="r1755">
+        <changelogtext>Added secure screen setting</changelogtext>
+        <changelogtext>Removed usage of incorrect platform yes/no strings</changelogtext>
+	<changelogtext>Added biometric lock</changelogtext>
     </changelogversion>
 
-    <changelogversion changeDate="" versionName="r736">
-        <changelogtext>[b]Important![/b] Now chapters follow the order of the sources. [b]It's required that you update your entire library
-            before reading in order for them to be synced.[/b] Old behavior can be restored for a manga in the overflow menu of the chapters tab.
-        </changelogtext>
+    <changelogversion changeDate="Feb 21, 2020" versionName="r1662">
+        <changelogtext>Minor layout tweaks for better RTL support</changelogtext>
+        <changelogtext>Removed usage of AndroidX Webkit library</changelogtext>
     </changelogversion>
 
-    <changelogversion changeDate="" versionName="r724">
-        <changelogtext>Kissmanga covers may not load anymore. The only workaround is to update the details of the manga
-            from the info tab, or clearing the database (the latter won't fix covers from library manga).
-        </changelogtext>
+    <changelogversion changeDate="Feb 19, 2020" versionName="r1655">
+        <changelogtext>Default to light theme for android versions before Android 8</changelogtext>
+        <changelogtext>Changed default theme to System Default</changelogtext>
+	<changelogtext>Dark splash screen added</changelogtext>
+	<changelogtext>Minor system theme tweaks</changelogtext>
     </changelogversion>
 
 </changelog>

--- a/app/src/main/res/raw/changelog_debug.xml
+++ b/app/src/main/res/raw/changelog_debug.xml
@@ -2,17 +2,11 @@
 <changelog bulletedList="true">
 
     <changelogversion changeDate="Feb 28, 2020" versionName="r1781">
-        <changelogtext>Unused icon and LoginSource removed</changelogtext>
-        <changelogtext>Unlock string reworded</changelogtext>
 	<changelogtext>Changed check for system dark mode</changelogtext>
-	<changelogtext>Added ripple to menu icons</changelogtext>
-	<changelogtext>Top padding removed from more screen</changelogtext>
 	<changelogtext>Bottom Nav labels always shown</changelogtext>
     </changelogversion>
     
     <changelogversion changeDate="Feb 26, 2020" versionName="r1771">
-        <changelogtext>Added description for secure screen setting</changelogtext>
-        <changelogtext>Linting Fixes</changelogtext>
 	<changelogtext>Migrated to bottom navigation</changelogtext>
     </changelogversion>
     
@@ -21,32 +15,43 @@
         <changelogtext>Fix crash when loading invalid extensions</changelogtext>
     </changelogversion>
 
-    <changelogversion changeDate="Feb 23, 2020" versionName="r1761">
-        <changelogtext>Crash reports setting moved to advanced</changelogtext>
-        <changelogtext>Refresh webtoon adapter on image property changed</changelogtext>
-	<changelogtext>Webtoon page padding now sets on page bind</changelogtext>
-	<changelogtext>Null file paths hidden when creating backups</changelogtext>
-	<changelogtext>Added Webtoon with Padding Viewer</changelogtext>
-	<changelogtext>"Clear" renamed to "Cancell All" in Download queue</changelogtext>
-	<changelogtext>Color filter moved behind reader toolbars</changelogtext>
-    </changelogversion>
-
     <changelogversion changeDate="Feb 22, 2020" versionName="r1755">
-        <changelogtext>Added secure screen setting</changelogtext>
-        <changelogtext>Removed usage of incorrect platform yes/no strings</changelogtext>
 	<changelogtext>Added biometric lock</changelogtext>
     </changelogversion>
 
-    <changelogversion changeDate="Feb 21, 2020" versionName="r1662">
-        <changelogtext>Minor layout tweaks for better RTL support</changelogtext>
-        <changelogtext>Removed usage of AndroidX Webkit library</changelogtext>
+    <changelogversion changeDate="" versionName="r1340">
+        <changelogtext>A new screen for managing extensions was added. If you previously installed extensions from FDroid,
+            you will have to uninstall all of them first (tap on the extension then uninstall), otherwise you won't be able
+            to update them due to signature mismatch. You won't lose anything in this process as the extensions themselves
+            don't store anything.
+        </changelogtext>
     </changelogversion>
 
-    <changelogversion changeDate="Feb 19, 2020" versionName="r1655">
-        <changelogtext>Default to light theme for android versions before Android 8</changelogtext>
-        <changelogtext>Changed default theme to System Default</changelogtext>
-	<changelogtext>Dark splash screen added</changelogtext>
-	<changelogtext>Minor system theme tweaks</changelogtext>
+    <changelogversion changeDate="" versionName="r959">
+        <changelogtext>The download manager has been rewritten and it's possible some of your downloads
+            aren't recognized anymore. You may have to check your downloads folder and manually delete those.
+        </changelogtext>
+        <changelogtext>You can now download to any folder in your SD card.</changelogtext>
+        <changelogtext>The download directory setting has been reset.</changelogtext>
+    </changelogversion>
+
+    <changelogversion changeDate="" versionName="r857">
+        <changelogtext>[b]Important![/b] Delete after read has been updated.
+            This means the value has been reset set to disabled.
+            This can be changed in Settings > Downloads
+        </changelogtext>
+    </changelogversion>
+
+    <changelogversion changeDate="" versionName="r736">
+        <changelogtext>[b]Important![/b] Now chapters follow the order of the sources. [b]It's required that you update your entire library
+            before reading in order for them to be synced.[/b] Old behavior can be restored for a manga in the overflow menu of the chapters tab.
+        </changelogtext>
+    </changelogversion>
+
+    <changelogversion changeDate="" versionName="r724">
+        <changelogtext>Kissmanga covers may not load anymore. The only workaround is to update the details of the manga
+            from the info tab, or clearing the database (the latter won't fix covers from library manga).
+        </changelogtext>
     </changelogversion>
 
 </changelog>


### PR DESCRIPTION
The old changelog was really outdated, so I modified the changelog by cross-referencing the dates of the commits from: https://github.com/inorichi/tachiyomi/commits/master and the dates next to the APK files in: https://tachiyomi.kanade.eu/.

Only the latest version of any given date is included in this change, and only the most recent 7 were included (because I thought it'd be sufficient for the in-app changelog).