### PR TITLE
Added config to hide transition page when not needed

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -133,6 +133,8 @@ object PreferenceKeys {
 
     const val downloadBadge = "display_download_badge"
 
+    const val alwaysShowChapterTransition = "always_show_chapter_transition"
+
     fun trackUsername(syncId: Int) = "pref_mangasync_username_$syncId"
 
     fun trackPassword(syncId: Int) = "pref_mangasync_password_$syncId"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -203,4 +203,6 @@ class PreferencesHelper(val context: Context) {
     fun migrateFlags() = rxPrefs.getInteger("migrate_flags", Int.MAX_VALUE)
 
     fun trustedSignatures() = rxPrefs.getStringSet("trusted_signatures", emptySet())
+
+    fun alwaysShowChapterTransition() = rxPrefs.getBoolean(Keys.alwaysShowChapterTransition, true)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderSettingsSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderSettingsSheet.kt
@@ -15,6 +15,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.pager.PagerViewer
 import eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonViewer
 import eu.kanade.tachiyomi.util.view.visible
 import eu.kanade.tachiyomi.widget.IgnoreFirstSpinnerListener
+import kotlinx.android.synthetic.main.reader_settings_sheet.always_show_chapter_transition
 import kotlinx.android.synthetic.main.reader_settings_sheet.background_color
 import kotlinx.android.synthetic.main.reader_settings_sheet.crop_borders
 import kotlinx.android.synthetic.main.reader_settings_sheet.crop_borders_webtoon
@@ -31,8 +32,6 @@ import kotlinx.android.synthetic.main.reader_settings_sheet.show_page_number
 import kotlinx.android.synthetic.main.reader_settings_sheet.viewer
 import kotlinx.android.synthetic.main.reader_settings_sheet.webtoon_prefs_group
 import kotlinx.android.synthetic.main.reader_settings_sheet.zoom_start
-import kotlinx.android.synthetic.main.reader_settings_sheet.always_show_chapter_transition
-import kotlinx.android.synthetic.main.reader_settings_sheet.always_show_chapter_transition_webtoon
 import uy.kohesive.injekt.injectLazy
 
 /**
@@ -86,6 +85,7 @@ class ReaderSettingsSheet(private val activity: ReaderActivity) : BottomSheetDia
         }
         keepscreen.bindToPreference(preferences.keepScreenOn())
         long_tap.bindToPreference(preferences.readWithLongTap())
+        always_show_chapter_transition.bindToPreference(preferences.alwaysShowChapterTransition())
     }
 
     /**
@@ -98,7 +98,6 @@ class ReaderSettingsSheet(private val activity: ReaderActivity) : BottomSheetDia
         crop_borders.bindToPreference(preferences.cropBorders())
         pad_pages_vert_webtoon.bindToPreference(preferences.padPagesVertWebtoon())
         page_transitions.bindToPreference(preferences.pageTransitions())
-        always_show_chapter_transition.bindToPreference(preferences.alwaysShowChapterTransition())
     }
 
     /**
@@ -108,7 +107,6 @@ class ReaderSettingsSheet(private val activity: ReaderActivity) : BottomSheetDia
         webtoon_prefs_group.visible()
         crop_borders_webtoon.bindToPreference(preferences.cropBordersWebtoon())
         pad_pages_vert_webtoon.bindToPreference(preferences.padPagesVertWebtoon())
-        always_show_chapter_transition_webtoon.bindToPreference(preferences.alwaysShowChapterTransition())
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderSettingsSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderSettingsSheet.kt
@@ -31,6 +31,8 @@ import kotlinx.android.synthetic.main.reader_settings_sheet.show_page_number
 import kotlinx.android.synthetic.main.reader_settings_sheet.viewer
 import kotlinx.android.synthetic.main.reader_settings_sheet.webtoon_prefs_group
 import kotlinx.android.synthetic.main.reader_settings_sheet.zoom_start
+import kotlinx.android.synthetic.main.reader_settings_sheet.always_show_chapter_transition
+import kotlinx.android.synthetic.main.reader_settings_sheet.always_show_chapter_transition_webtoon
 import uy.kohesive.injekt.injectLazy
 
 /**
@@ -96,6 +98,7 @@ class ReaderSettingsSheet(private val activity: ReaderActivity) : BottomSheetDia
         crop_borders.bindToPreference(preferences.cropBorders())
         pad_pages_vert_webtoon.bindToPreference(preferences.padPagesVertWebtoon())
         page_transitions.bindToPreference(preferences.pageTransitions())
+        always_show_chapter_transition.bindToPreference(preferences.alwaysShowChapterTransition())
     }
 
     /**
@@ -105,6 +108,7 @@ class ReaderSettingsSheet(private val activity: ReaderActivity) : BottomSheetDia
         webtoon_prefs_group.visible()
         crop_borders_webtoon.bindToPreference(preferences.cropBordersWebtoon())
         pad_pages_vert_webtoon.bindToPreference(preferences.padPagesVertWebtoon())
+        always_show_chapter_transition_webtoon.bindToPreference(preferences.alwaysShowChapterTransition())
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -43,6 +43,9 @@ class PagerConfig(private val viewer: PagerViewer, preferences: PreferencesHelpe
     var doubleTapAnimDuration = 500
         private set
 
+    var alwaysShowChapterTransition = true
+        private set
+
     init {
         preferences.readWithTapping()
                 .register({ tappingEnabled = it })
@@ -70,6 +73,9 @@ class PagerConfig(private val viewer: PagerViewer, preferences: PreferencesHelpe
 
         preferences.readWithVolumeKeysInverted()
                 .register({ volumeKeysInverted = it })
+
+        preferences.alwaysShowChapterTransition()
+                .register({ alwaysShowChapterTransition = it })
     }
 
     fun unsubscribe() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -185,7 +185,8 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
      */
     private fun setChaptersInternal(chapters: ViewerChapters) {
         Timber.d("setChaptersInternal")
-        adapter.setChapters(chapters)
+        var forceTransition = config.alwaysShowChapterTransition || adapter.items.getOrNull(pager.currentItem) is ChapterTransition
+        adapter.setChapters(chapters, forceTransition)
 
         // Layout the pager once a chapter is being set
         if (pager.visibility == View.GONE) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.viewpager.widget.PagerAdapter
 import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
+import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
 import eu.kanade.tachiyomi.widget.ViewPagerAdapter
@@ -28,7 +29,7 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
      * next/previous chapter to allow seamless transitions and inverting the pages if the viewer
      * has R2L direction.
      */
-    fun setChapters(chapters: ViewerChapters) {
+    fun setChapters(chapters: ViewerChapters, forceTransition: Boolean) {
         val newItems = mutableListOf<Any>()
 
         // Add previous chapter pages and transition.
@@ -40,7 +41,11 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
                 newItems.addAll(prevPages.takeLast(2))
             }
         }
-        newItems.add(ChapterTransition.Prev(chapters.currChapter, chapters.prevChapter))
+
+        // Skip transition page if  the chapter is loaded & current page is not a transition page
+        if (forceTransition || chapters.prevChapter?.state !is ReaderChapter.State.Loaded) {
+            newItems.add(ChapterTransition.Prev(chapters.currChapter, chapters.prevChapter))
+        }
 
         // Add current chapter.
         val currPages = chapters.currChapter.pages
@@ -50,7 +55,13 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
 
         // Add next chapter transition and pages.
         nextTransition = ChapterTransition.Next(chapters.currChapter, chapters.nextChapter)
-                .also { newItems.add(it) }
+                .also {
+                    if (forceTransition ||
+                            chapters.nextChapter?.state !is ReaderChapter.State.Loaded) {
+                        newItems.add(it)
+                    }
+                }
+
         if (chapters.nextChapter != null) {
             // Add at most two pages, because this chapter will be selected before the user can
             // swap more pages.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -6,6 +6,7 @@ import android.widget.LinearLayout
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
+import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
 
@@ -24,7 +25,7 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
      * Updates this adapter with the given [chapters]. It handles setting a few pages of the
      * next/previous chapter to allow seamless transitions.
      */
-    fun setChapters(chapters: ViewerChapters) {
+    fun setChapters(chapters: ViewerChapters, forceTransition: Boolean) {
         val newItems = mutableListOf<Any>()
 
         // Add previous chapter pages and transition.
@@ -36,7 +37,11 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
                 newItems.addAll(prevPages.takeLast(2))
             }
         }
-        newItems.add(ChapterTransition.Prev(chapters.currChapter, chapters.prevChapter))
+
+        // Skip transition page if  the chapter is loaded & current page is not a transition page
+        if (forceTransition || chapters.prevChapter?.state !is ReaderChapter.State.Loaded) {
+            newItems.add(ChapterTransition.Prev(chapters.currChapter, chapters.prevChapter))
+        }
 
         // Add current chapter.
         val currPages = chapters.currChapter.pages
@@ -45,7 +50,10 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
         }
 
         // Add next chapter transition and pages.
-        newItems.add(ChapterTransition.Next(chapters.currChapter, chapters.nextChapter))
+        if (forceTransition || chapters.nextChapter?.state !is ReaderChapter.State.Loaded) {
+            newItems.add(ChapterTransition.Next(chapters.currChapter, chapters.nextChapter))
+        }
+
         if (chapters.nextChapter != null) {
             // Add at most two pages, because this chapter will be selected before the user can
             // swap more pages.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -37,6 +37,9 @@ class WebtoonConfig(preferences: PreferencesHelper = Injekt.get()) {
     var doubleTapAnimDuration = 500
         private set
 
+    var alwaysShowChapterTransition = true
+        private set
+
     init {
         preferences.readWithTapping()
                 .register({ tappingEnabled = it })
@@ -58,6 +61,9 @@ class WebtoonConfig(preferences: PreferencesHelper = Injekt.get()) {
 
         preferences.readWithVolumeKeysInverted()
                 .register({ volumeKeysInverted = it })
+
+        preferences.alwaysShowChapterTransition()
+                .register({ alwaysShowChapterTransition = it })
     }
 
     fun unsubscribe() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -175,7 +175,8 @@ class WebtoonViewer(val activity: ReaderActivity) : BaseViewer {
      */
     override fun setChapters(chapters: ViewerChapters) {
         Timber.d("setChapters")
-        adapter.setChapters(chapters)
+        var forceTransition = config.alwaysShowChapterTransition || currentPage is ChapterTransition
+        adapter.setChapters(chapters, forceTransition)
 
         if (recycler.visibility == View.GONE) {
             Timber.d("Recycler first layout")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
@@ -103,6 +103,12 @@ class SettingsReaderController : SettingsController() {
                 defaultValue = false
             }
         }
+        switchPreference {
+            key = Keys.alwaysShowChapterTransition
+            titleRes = R.string.pref_always_show_chapter_transition
+            defaultValue = true
+        }
+
         preferenceCategory {
             titleRes = R.string.pager_viewer
 

--- a/app/src/main/res/layout/reader_settings_sheet.xml
+++ b/app/src/main/res/layout/reader_settings_sheet.xml
@@ -152,11 +152,20 @@
         android:textColor="?android:attr/textColorSecondary"
         app:layout_constraintTop_toBottomOf="@id/keepscreen" />
 
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/always_show_chapter_transition"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/pref_always_show_chapter_transition"
+        android:textColor="?android:attr/textColorSecondary"
+        app:layout_constraintTop_toBottomOf="@id/long_tap" />
+
     <androidx.legacy.widget.Space
         android:id="@+id/end_general_preferences"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="@id/long_tap" />
+        app:layout_constraintBottom_toBottomOf="@id/always_show_chapter_transition" />
 
     <!-- Pager preferences -->
 
@@ -227,16 +236,6 @@
         android:textColor="?android:attr/textColorSecondary"
         app:layout_constraintTop_toBottomOf="@id/crop_borders" />
 
-
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/always_show_chapter_transition"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="@string/pref_always_show_chapter_transition"
-        android:textColor="?android:attr/textColorSecondary"
-        app:layout_constraintTop_toBottomOf="@id/page_transitions" />
-
     <!-- Webtoon preferences -->
 
     <TextView
@@ -268,15 +267,6 @@
         android:textColor="?android:attr/textColorSecondary"
         app:layout_constraintTop_toBottomOf="@id/crop_borders_webtoon" />
 
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/always_show_chapter_transition_webtoon"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="@string/pref_always_show_chapter_transition"
-        android:textColor="?android:attr/textColorSecondary"
-        app:layout_constraintTop_toBottomOf="@id/pad_pages_vert_webtoon" />
-
     <!-- Groups of preferences -->
 
     <androidx.constraintlayout.widget.Group
@@ -284,7 +274,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:constraint_referenced_ids="pager_prefs,scale_type_text,scale_type,zoom_start_text,zoom_start,crop_borders,page_transitions,always_show_chapter_transition"
+        app:constraint_referenced_ids="pager_prefs,scale_type_text,scale_type,zoom_start_text,zoom_start,crop_borders,page_transitions"
         tools:visibility="visible" />
 
     <androidx.constraintlayout.widget.Group
@@ -292,7 +282,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:constraint_referenced_ids="webtoon_prefs,crop_borders_webtoon,pad_pages_vert_webtoon,always_show_chapter_transition_webtoon" />
+        app:constraint_referenced_ids="webtoon_prefs,crop_borders_webtoon,pad_pages_vert_webtoon" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/verticalcenter"

--- a/app/src/main/res/layout/reader_settings_sheet.xml
+++ b/app/src/main/res/layout/reader_settings_sheet.xml
@@ -227,6 +227,16 @@
         android:textColor="?android:attr/textColorSecondary"
         app:layout_constraintTop_toBottomOf="@id/crop_borders" />
 
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/always_show_chapter_transition"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/pref_always_show_chapter_transition"
+        android:textColor="?android:attr/textColorSecondary"
+        app:layout_constraintTop_toBottomOf="@id/page_transitions" />
+
     <!-- Webtoon preferences -->
 
     <TextView
@@ -258,6 +268,15 @@
         android:textColor="?android:attr/textColorSecondary"
         app:layout_constraintTop_toBottomOf="@id/crop_borders_webtoon" />
 
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/always_show_chapter_transition_webtoon"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/pref_always_show_chapter_transition"
+        android:textColor="?android:attr/textColorSecondary"
+        app:layout_constraintTop_toBottomOf="@id/pad_pages_vert_webtoon" />
+
     <!-- Groups of preferences -->
 
     <androidx.constraintlayout.widget.Group
@@ -265,7 +284,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:constraint_referenced_ids="pager_prefs,scale_type_text,scale_type,zoom_start_text,zoom_start,crop_borders,page_transitions"
+        app:constraint_referenced_ids="pager_prefs,scale_type_text,scale_type,zoom_start_text,zoom_start,crop_borders,page_transitions,always_show_chapter_transition"
         tools:visibility="visible" />
 
     <androidx.constraintlayout.widget.Group
@@ -273,7 +292,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:constraint_referenced_ids="webtoon_prefs,crop_borders_webtoon,pad_pages_vert_webtoon" />
+        app:constraint_referenced_ids="webtoon_prefs,crop_borders_webtoon,pad_pages_vert_webtoon,always_show_chapter_transition_webtoon" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/verticalcenter"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,6 +264,7 @@
     <string name="color_filter_g_value">G</string>
     <string name="color_filter_b_value">B</string>
     <string name="color_filter_a_value">A</string>
+    <string name="pref_always_show_chapter_transition">Always show chapter transition</string>
 
       <!-- Downloads section -->
     <string name="pref_download_directory">Download location</string>


### PR DESCRIPTION
As per issue https://github.com/inorichi/tachiyomi/issues/1653

The transition page will not show if the "force" setting is off and the next/previous chapter has loaded. At a normal reading pace, this should be consistently the case due to last page kicking off preload.

Transition/loading page will show regardless of the setting if the page hasn't loaded yet or failed to load.

