### PR TITLE
Added support for tap-centered zoom on double tap in Pager viewer

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -135,6 +135,8 @@ object PreferenceKeys {
 
     const val alwaysShowChapterTransition = "always_show_chapter_transition"
 
+    const val doubleTapZoomStyle = "double_tap_zoom_style"
+
     fun trackUsername(syncId: Int) = "pref_mangasync_username_$syncId"
 
     fun trackPassword(syncId: Int) = "pref_mangasync_password_$syncId"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -205,4 +205,6 @@ class PreferencesHelper(val context: Context) {
     fun trustedSignatures() = rxPrefs.getStringSet("trusted_signatures", emptySet())
 
     fun alwaysShowChapterTransition() = rxPrefs.getBoolean(Keys.alwaysShowChapterTransition, true)
+
+    fun doubleTapZoomStyle() = rxPrefs.getInteger(Keys.doubleTapZoomStyle, 1)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderSettingsSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderSettingsSheet.kt
@@ -20,6 +20,7 @@ import kotlinx.android.synthetic.main.reader_settings_sheet.background_color
 import kotlinx.android.synthetic.main.reader_settings_sheet.crop_borders
 import kotlinx.android.synthetic.main.reader_settings_sheet.crop_borders_webtoon
 import kotlinx.android.synthetic.main.reader_settings_sheet.cutout_short
+import kotlinx.android.synthetic.main.reader_settings_sheet.double_tap_zoom_style
 import kotlinx.android.synthetic.main.reader_settings_sheet.fullscreen
 import kotlinx.android.synthetic.main.reader_settings_sheet.keepscreen
 import kotlinx.android.synthetic.main.reader_settings_sheet.long_tap
@@ -104,7 +105,7 @@ class ReaderSettingsSheet(private val activity: ReaderActivity) : BottomSheetDia
         scale_type.bindToPreference(preferences.imageScaleType(), 1)
         zoom_start.bindToPreference(preferences.zoomStart(), 1)
         crop_borders.bindToPreference(preferences.cropBorders())
-        pad_pages_vert_webtoon.bindToPreference(preferences.padPagesVertWebtoon())
+        double_tap_zoom_style.bindToPreference(preferences.doubleTapZoomStyle(), 1)
         page_transitions.bindToPreference(preferences.pageTransitions())
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -16,6 +16,8 @@ class PagerConfig(private val viewer: PagerViewer, preferences: PreferencesHelpe
 
     var imagePropertyChangedListener: (() -> Unit)? = null
 
+    var doubleTapZoomStyleChangedListener: ((DoubleTapZoomStyle) -> Unit)? = null
+
     var tappingEnabled = true
         private set
 
@@ -44,6 +46,9 @@ class PagerConfig(private val viewer: PagerViewer, preferences: PreferencesHelpe
         private set
 
     var alwaysShowChapterTransition = true
+        private set
+
+    var doubleTapZoomStyle = DoubleTapZoomStyle.Fixed
         private set
 
     init {
@@ -76,6 +81,9 @@ class PagerConfig(private val viewer: PagerViewer, preferences: PreferencesHelpe
 
         preferences.alwaysShowChapterTransition()
                 .register({ alwaysShowChapterTransition = it })
+
+        preferences.doubleTapZoomStyle()
+                .register({ doubleTapZoomStyleFromPreference(it) }, { doubleTapZoomStyleChangedListener?.invoke(doubleTapZoomStyle) })
     }
 
     fun unsubscribe() {
@@ -93,6 +101,13 @@ class PagerConfig(private val viewer: PagerViewer, preferences: PreferencesHelpe
                 .doOnNext(onChanged)
                 .subscribe()
                 .addTo(subscriptions)
+    }
+
+    private fun doubleTapZoomStyleFromPreference(value: Int) {
+        doubleTapZoomStyle = when (value) {
+            1 -> DoubleTapZoomStyle.Fixed
+            else -> DoubleTapZoomStyle.Center
+        }
     }
 
     private fun zoomTypeFromPreference(value: Int) {
@@ -114,5 +129,9 @@ class PagerConfig(private val viewer: PagerViewer, preferences: PreferencesHelpe
 
     enum class ZoomType {
         Left, Center, Right
+    }
+
+    enum class DoubleTapZoomStyle {
+        Fixed, Center
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -299,11 +299,13 @@ class PagerPageHolder(
         if (subsamplingImageView != null) return subsamplingImageView!!
 
         val config = viewer.config
-
         subsamplingImageView = SubsamplingScaleImageView(context).apply {
             layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
             setMaxTileSize(viewer.activity.maxBitmapSize)
-            setDoubleTapZoomStyle(SubsamplingScaleImageView.ZOOM_FOCUS_FIXED)
+            setDoubleTapZoomStyle(when (config.doubleTapZoomStyle) {
+                PagerConfig.DoubleTapZoomStyle.Fixed -> SubsamplingScaleImageView.ZOOM_FOCUS_FIXED
+                else -> SubsamplingScaleImageView.ZOOM_FOCUS_CENTER
+            })
             setDoubleTapZoomDuration(config.doubleTapAnimDuration)
             setPanLimit(SubsamplingScaleImageView.PAN_LIMIT_INSIDE)
             setMinimumScaleType(config.imageScaleType)
@@ -466,5 +468,12 @@ class PagerPageHolder(
                     }
                 })
                 .into(this)
+    }
+
+    fun updateZoomStyle(zoomStyle: PagerConfig.DoubleTapZoomStyle) {
+        subsamplingImageView?.setDoubleTapZoomStyle(when (zoomStyle) {
+            PagerConfig.DoubleTapZoomStyle.Fixed -> SubsamplingScaleImageView.ZOOM_FOCUS_FIXED
+            else -> SubsamplingScaleImageView.ZOOM_FOCUS_CENTER
+        })
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -101,6 +101,15 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
         config.imagePropertyChangedListener = {
             refreshAdapter()
         }
+
+        config.doubleTapZoomStyleChangedListener = {
+            for (i in 0 until pager.childCount) {
+                val ph = pager.getChildAt(i)
+                if (ph is PagerPageHolder) {
+                    ph.updateZoomStyle(it)
+                }
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
@@ -111,7 +111,14 @@ class SettingsReaderController : SettingsController() {
 
         preferenceCategory {
             titleRes = R.string.pager_viewer
-
+            intListPreference {
+                key = Keys.doubleTapZoomStyle
+                titleRes = R.string.pref_double_tap_zoom_style
+                entriesRes = arrayOf(R.string.double_tap_zoom_style_fixed, R.string.double_tap_zoom_style_center)
+                entryValues = arrayOf("1", "2")
+                defaultValue = "1"
+                summary = "%s"
+            }
             switchPreference {
                 key = Keys.enableTransitions
                 titleRes = R.string.pref_page_transitions

--- a/app/src/main/res/layout/reader_settings_sheet.xml
+++ b/app/src/main/res/layout/reader_settings_sheet.xml
@@ -212,6 +212,25 @@
         app:layout_constraintStart_toEndOf="@id/verticalcenter"
         app:layout_constraintTop_toBottomOf="@id/scale_type" />
 
+    <TextView
+        android:id="@+id/double_tap_zoom_style_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/pref_double_tap_zoom_style"
+        app:layout_constraintBaseline_toBaselineOf="@id/double_tap_zoom_style"
+        app:layout_constraintEnd_toStartOf="@id/verticalcenter"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatSpinner
+        android:id="@+id/double_tap_zoom_style"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:entries="@array/double_tap_zoom_style"
+        app:layout_constraintEnd_toEndOf="@id/spinner_end"
+        app:layout_constraintStart_toEndOf="@id/verticalcenter"
+        app:layout_constraintTop_toBottomOf="@id/zoom_start" />
+
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/crop_borders"
         android:layout_width="match_parent"
@@ -219,7 +238,7 @@
         android:layout_marginTop="10dp"
         android:text="@string/pref_crop_borders"
         android:textColor="?android:attr/textColorSecondary"
-        app:layout_constraintTop_toBottomOf="@id/zoom_start" />
+        app:layout_constraintTop_toBottomOf="@id/double_tap_zoom_style" />
 
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/page_transitions"
@@ -266,7 +285,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:constraint_referenced_ids="pager_prefs,scale_type_text,scale_type,zoom_start_text,zoom_start,crop_borders,page_transitions"
+        app:constraint_referenced_ids="pager_prefs,scale_type_text,scale_type,zoom_start_text,zoom_start,crop_borders,page_transitions,double_tap_zoom_style,double_tap_zoom_style_text"
         tools:visibility="visible" />
 
     <androidx.constraintlayout.widget.Group

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -53,6 +53,16 @@
         <item>@string/scale_type_smart_fit</item>
     </string-array>
 
+    <string-array name="double_tap_zoom_style">
+        <item>@string/double_tap_zoom_style_fixed</item>
+        <item>@string/double_tap_zoom_style_center</item>
+    </string-array>
+
+    <string-array name="double_tap_zoom_style_values">
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
     <string-array name="image_scale_type_values">
         <item>1</item>
         <item>2</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -265,6 +265,9 @@
     <string name="color_filter_b_value">B</string>
     <string name="color_filter_a_value">A</string>
     <string name="pref_always_show_chapter_transition">Always show chapter transition</string>
+    <string name="pref_double_tap_zoom_style">Double tap zoom style</string>
+    <string name="double_tap_zoom_style_fixed">Page center</string>
+    <string name="double_tap_zoom_style_center">Tap location</string>
 
       <!-- Downloads section -->
     <string name="pref_download_directory">Download location</string>


### PR DESCRIPTION
Zoom style for double tap on Pager viewer has been hardcoded to ZOOM_FOCUS_FIXED, working around image center.

A more intuitive type of zoom is ZOOM_FOCUS_CENTER, which zooms around double tap location.

This PR adds a setting to configure centering of the double-tap zoom. Can also serve as baseline for other zoom double-tap zoom configurations (i.e. #476)