### PR TITLE
Fix for perpetually loading chapters

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -26,7 +26,7 @@ class ChapterLoader(
      * completes if the chapter is already loaded.
      */
     fun loadChapter(chapter: ReaderChapter): Completable {
-        if (chapter.state is ReaderChapter.State.Loaded) {
+        if (chapterIsReady(chapter)) {
             return Completable.complete()
         }
 
@@ -59,6 +59,13 @@ class ChapterLoader(
                 }
                 .toCompletable()
                 .doOnError { chapter.state = ReaderChapter.State.Error(it) }
+    }
+
+    /**
+     * Checks [chapter] to be loaded based on present pages and loader in addition to state.
+     */
+    private fun chapterIsReady(chapter: ReaderChapter): Boolean {
+        return chapter.state is ReaderChapter.State.Loaded && chapter.pageLoader != null && chapter.pages?.count() != 0
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -65,7 +65,7 @@ class ChapterLoader(
      * Checks [chapter] to be loaded based on present pages and loader in addition to state.
      */
     private fun chapterIsReady(chapter: ReaderChapter): Boolean {
-        return chapter.state is ReaderChapter.State.Loaded && chapter.pageLoader != null && chapter.pages?.count() != 0
+        return chapter.state is ReaderChapter.State.Loaded && chapter.pageLoader != null
     }
 
     /**


### PR DESCRIPTION
Related issue: https://github.com/inorichi/tachiyomi/issues/2715

From time to time, a downloaded chapter's pages don't show up, instead
showing an infinite progress spinner with no error message or timeout. 

After reproducing said issue, the reason behind it is that `chapter.pageLoader` is `null` while the `state` is `Loaded`. PagerPageHolder simply has a stub for that case:
`val loader = page.chapter.pageLoader ?: return`

Normally this shouldn't ever happen since `state` gets set to `Wait` immediately `pageLoader` gets recycled. It might possibly be happening if pages finish loading after chapter gets recycled, for some reason, which would set the `state` to `Loaded` again (https://github.com/inorichi/tachiyomi/blob/master/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt#L47-L59)

This fix simply extends chapter ready check with loader present.