### PR TITLE
Faulty preload fix

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -149,7 +149,7 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
         // 1. Going to next chapter from chapter transition
         // 2. Going between pages of same chapter
         // 3. Next chapter page
-        return when (page?.chapter) {
+        return when (page!!.chapter) {
             (currentPage as? ChapterTransition.Next)?.to -> true
             (currentPage as? ReaderPage)?.chapter -> true
             adapter.nextTransition?.to -> true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -149,18 +149,12 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
         // 1. Going to next chapter from chapter transition
         // 2. Going between pages of same chapter
         // 3. Next chapter page
-        when (page?.chapter) {
-            (currentPage as? ChapterTransition.Next)?.to -> return true
-            (currentPage as? ReaderPage)?.chapter -> return true
-            adapter.nextTransition?.to -> return true
+        return when (page?.chapter) {
+            (currentPage as? ChapterTransition.Next)?.to -> true
+            (currentPage as? ReaderPage)?.chapter -> true
+            adapter.nextTransition?.to -> true
+            else -> false
         }
-
-        // Other cases, no preload is allowed.
-        // 1. Going back to chapter from Next transition
-        // 2. Going back to chapter from From transition
-        // 3. Going back to a loaded page of previous chapter (no transition)
-        // 4. Going to previous chapter page from a chapter transition
-        return false
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -136,17 +136,11 @@ class WebtoonViewer(val activity: ReaderActivity) : BaseViewer {
         // Allow preload for
         // 1. Going between pages of same chapter
         // 2. Next chapter page
-        when (page?.chapter) {
-            (currentPage as? ReaderPage)?.chapter -> return true
-            nextChapter -> return true
+        return when (page?.chapter) {
+            (currentPage as? ReaderPage)?.chapter -> true
+            nextChapter -> true
+            else-> false
         }
-
-        // Other cases, no preload is allowed.
-        // 1. Going back to chapter from Next transition
-        // 2. Going back to chapter from From transition
-        // 3. Going back to a loaded page of previous chapter (no transition)
-        // 4. Going to previous chapter page from a chapter transition
-        return false
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -125,35 +125,27 @@ class WebtoonViewer(val activity: ReaderActivity) : BaseViewer {
 
     private fun checkAllowPreload(page: ReaderPage?): Boolean {
         // Page is transition page - preload allowed
-        if (page == null)
-            return true
+        page == null ?: return true
 
         // Initial opening - preload allowed
-        if (currentPage == null) {
-            return true
-        }
+        currentPage == null ?: return true
 
-        // Going to previous chapter page from a chapter transition - no preload
-        if (page.chapter == (currentPage as? ChapterTransition.Prev)?.to) {
-            return false
-        }
-
-        // Going between pages of same chapter - can preload
-        if (page.chapter == (currentPage as? ReaderPage)?.chapter) {
-            return true
-        }
-
-        // Next chapter page - allow preload, necessary for 1-3 page chapters.
         val nextItem = adapter.items.getOrNull(adapter.items.count() - 1)
         val nextChapter = (nextItem as? ChapterTransition.Next)?.to ?: (nextItem as? ReaderPage)?.chapter
-        if (page.chapter == nextChapter) {
-            return true
+
+        // Allow preload for
+        // 1. Going between pages of same chapter
+        // 2. Next chapter page
+        when (page?.chapter) {
+            (currentPage as? ReaderPage)?.chapter -> return true
+            nextChapter -> return true
         }
 
-        // Other cases, no preload is necessary.
+        // Other cases, no preload is allowed.
         // 1. Going back to chapter from Next transition
         // 2. Going back to chapter from From transition
         // 3. Going back to a loaded page of previous chapter (no transition)
+        // 4. Going to previous chapter page from a chapter transition
         return false
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -136,10 +136,10 @@ class WebtoonViewer(val activity: ReaderActivity) : BaseViewer {
         // Allow preload for
         // 1. Going between pages of same chapter
         // 2. Next chapter page
-        return when (page?.chapter) {
+        return when (page!!.chapter) {
             (currentPage as? ReaderPage)?.chapter -> true
             nextChapter -> true
-            else-> false
+            else -> false
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -74,10 +74,11 @@ class WebtoonViewer(val activity: ReaderActivity) : BaseViewer {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 val position = layoutManager.findLastEndVisibleItemPosition()
                 val item = adapter.items.getOrNull(position)
+                val allowPreload = checkAllowPreload(item as? ReaderPage)
                 if (item != null && currentPage != item) {
                     currentPage = item
                     when (item) {
-                        is ReaderPage -> onPageSelected(item, position)
+                        is ReaderPage -> onPageSelected(item, allowPreload)
                         is ChapterTransition -> onTransitionSelected(item)
                     }
                 }
@@ -122,6 +123,40 @@ class WebtoonViewer(val activity: ReaderActivity) : BaseViewer {
         frame.addView(recycler)
     }
 
+    private fun checkAllowPreload(page: ReaderPage?): Boolean {
+        // Page is transition page - preload allowed
+        if (page == null)
+            return true
+
+        // Initial opening - preload allowed
+        if (currentPage == null) {
+            return true
+        }
+
+        // Going to previous chapter page from a chapter transition - no preload
+        if (page.chapter == (currentPage as? ChapterTransition.Prev)?.to) {
+            return false
+        }
+
+        // Going between pages of same chapter - can preload
+        if (page.chapter == (currentPage as? ReaderPage)?.chapter) {
+            return true
+        }
+
+        // Next chapter page - allow preload, necessary for 1-3 page chapters.
+        val nextItem = adapter.items.getOrNull(adapter.items.count() - 1)
+        val nextChapter = (nextItem as? ChapterTransition.Next)?.to ?: (nextItem as? ReaderPage)?.chapter
+        if (page.chapter == nextChapter) {
+            return true
+        }
+
+        // Other cases, no preload is necessary.
+        // 1. Going back to chapter from Next transition
+        // 2. Going back to chapter from From transition
+        // 3. Going back to a loaded page of previous chapter (no transition)
+        return false
+    }
+
     /**
      * Returns the view this viewer uses.
      */
@@ -142,18 +177,20 @@ class WebtoonViewer(val activity: ReaderActivity) : BaseViewer {
      * Called from the RecyclerView listener when a [page] is marked as active. It notifies the
      * activity of the change and requests the preload of the next chapter if this is the last page.
      */
-    private fun onPageSelected(page: ReaderPage, position: Int) {
+    private fun onPageSelected(page: ReaderPage, allowPreload: Boolean) {
         val pages = page.chapter.pages!! // Won't be null because it's the loaded chapter
         Timber.d("onPageSelected: ${page.number}/${pages.size}")
         activity.onPageSelected(page)
 
         // Preload next chapter once we're within the last 3 pages of the current chapter
         val inPreloadRange = pages.size - page.number < 3
-        if (inPreloadRange) {
+        if (inPreloadRange && allowPreload) {
             Timber.d("Request preload next chapter because we're at page ${page.number} of ${pages.size}")
-            val transition = adapter.items.getOrNull(pages.size + 1) as? ChapterTransition.Next
-            if (transition?.to != null) {
-                activity.requestPreloadChapter(transition.to)
+            val nextItem = adapter.items.getOrNull(adapter.items.size - 1)
+            val transitionChapter = (nextItem as? ChapterTransition.Next)?.to ?: (nextItem as?ReaderPage)?.chapter
+            if (transitionChapter != null) {
+                Timber.d("Requesting to preload chapter ${transitionChapter.chapter.chapter_number}")
+                activity.requestPreloadChapter(transitionChapter)
             }
         }
     }


### PR DESCRIPTION
Fixes issues #2715, #2727, #2728 


### The issue and its reproduction

1. Disable "Always show chapter transition" in settings
2. Download a regular manga, with >3 chapters and >3 pages per chapter.
3. Open a middle chapter in manga, let's call it chapter 5. Casually scroll to the next chapter.
	Current chapter is now set to 6, prev is 5, next is 7.
4. Scroll one page back onto the last page.
	What happens here is the following:
	- We're at last page, so next chapter's (7) preload is requested. That chapter hasn't been loaded yet, so the preload begins.
	- We're at different chapter than previously, so chapters get shifted. Current is now 5, previous 4, next 6.
	- At the same time, since chapter 7 is not referenced anymore, it gets recycled.
	- Preload of chapter 7 is finished, and its status gets set to Loaded.

5. Scroll forward to chapter 7.
	- If fix #2717 is included, you will see a loading page that gets turned into pages of chapter 8 (since chapter 7 got reloaded with new page objects)
	- If fix #2717 is not included, you will get a never-ending loading animation.

We fix that by making sure preload is *really* needed on page change.

---
Also:

- Webtoon viewer used `adapter.items[pages.length+1]` to find next chapter for preload. Since we load additional 2 pages from previous chapter + the chapter transition into items, this would mostly return a ReaderPage object and made preload not work correctly. Also didn't work with disabled ChapterTransitions.
