### PR TITLE
[MAL] close response before proceeding chain in interceptor

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListInterceptor.kt
@@ -18,6 +18,7 @@ class MyAnimeListInterceptor(private val myanimelist: MyAnimeList) : Interceptor
 
         if (response.code == 400) {
             myanimelist.refreshLogin()
+            response.close()
             response = chain.proceed(updateRequest(request))
         }
 


### PR DESCRIPTION
Should've been closed but still worked since old version of okhttp ignored the leaky response. Newer versions now throw an exception.

![Screenshot_20200406-115245_Tachiyomi](https://user-images.githubusercontent.com/24946428/78634687-557e8980-7859-11ea-802d-6baec0ffc9b0.jpg)
