### PR TITLE
Update packagingOptions to exclude some META-INF

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,11 +89,14 @@ android {
     }
 
     packagingOptions {
-        exclude 'META-INF/DEPENDENCIES'
         exclude 'LICENSE.txt'
+        exclude 'META-INF/DEPENDENCIES'
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE'
+        exclude 'META-INF/*.version'
+        exclude 'META-INF/CHANGES'
+        exclude 'META-INF/README.md'
     }
 
     lintOptions {


### PR DESCRIPTION
META-INF really isn't needed, so let's Thanos snap it.