### PR TITLE
Bug/2894 covers not updating

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaThumbnail.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaThumbnail.kt
@@ -1,0 +1,28 @@
+package eu.kanade.tachiyomi.data.glide
+
+import eu.kanade.tachiyomi.data.database.models.Manga
+
+class MangaThumbnail(val manga: Manga) {
+
+    val url = manga.thumbnail_url
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as MangaThumbnail
+
+        if (manga != other.manga) return false
+        if (url != other.url) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = manga.hashCode()
+        result = 31 * result + (url?.hashCode() ?: 0)
+        return result
+    }
+}
+
+fun Manga.toMangaThumbnail() = MangaThumbnail(this)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaThumbnail.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaThumbnail.kt
@@ -2,27 +2,6 @@ package eu.kanade.tachiyomi.data.glide
 
 import eu.kanade.tachiyomi.data.database.models.Manga
 
-class MangaThumbnail(val manga: Manga) {
+data class MangaThumbnail(val manga: Manga, val url: String?)
 
-    val url = manga.thumbnail_url
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as MangaThumbnail
-
-        if (manga != other.manga) return false
-        if (url != other.url) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = manga.hashCode()
-        result = 31 * result + (url?.hashCode() ?: 0)
-        return result
-    }
-}
-
-fun Manga.toMangaThumbnail() = MangaThumbnail(this)
+fun Manga.toMangaThumbnail() = MangaThumbnail(this, this.thumbnail_url)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaThumbnailModelLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaThumbnailModelLoader.kt
@@ -31,7 +31,7 @@ import uy.kohesive.injekt.injectLazy
  *
  * @param context the application context.
  */
-class MangaModelLoader : ModelLoader<Manga, InputStream> {
+class MangaThumbnailModelLoader : ModelLoader<MangaThumbnail, InputStream> {
 
     /**
      * Cover cache where persistent covers are stored.
@@ -60,18 +60,18 @@ class MangaModelLoader : ModelLoader<Manga, InputStream> {
     private val cachedHeaders = hashMapOf<Long, LazyHeaders>()
 
     /**
-     * Factory class for creating [MangaModelLoader] instances.
+     * Factory class for creating [MangaThumbnailModelLoader] instances.
      */
-    class Factory : ModelLoaderFactory<Manga, InputStream> {
+    class Factory : ModelLoaderFactory<MangaThumbnail, InputStream> {
 
-        override fun build(multiFactory: MultiModelLoaderFactory): ModelLoader<Manga, InputStream> {
-            return MangaModelLoader()
+        override fun build(multiFactory: MultiModelLoaderFactory): ModelLoader<MangaThumbnail, InputStream> {
+            return MangaThumbnailModelLoader()
         }
 
         override fun teardown() {}
     }
 
-    override fun handles(model: Manga): Boolean {
+    override fun handles(model: MangaThumbnail): Boolean {
         return true
     }
 
@@ -83,16 +83,18 @@ class MangaModelLoader : ModelLoader<Manga, InputStream> {
      * @param height the height of the view where the resource will be loaded.
      */
     override fun buildLoadData(
-        manga: Manga,
-        width: Int,
-        height: Int,
-        options: Options
+            mangaThumbnail: MangaThumbnail,
+            width: Int,
+            height: Int,
+            options: Options
     ): ModelLoader.LoadData<InputStream>? {
         // Check thumbnail is not null or empty
-        val url = manga.thumbnail_url
+        val url = mangaThumbnail.url
         if (url == null || url.isEmpty()) {
             return null
         }
+
+        val manga = mangaThumbnail.manga
 
         if (url.startsWith("http")) {
             val source = sourceManager.get(manga.source) as? HttpSource
@@ -126,7 +128,7 @@ class MangaModelLoader : ModelLoader<Manga, InputStream> {
      *
      * @param manga the model.
      */
-    fun getHeaders(manga: Manga, source: HttpSource?): Headers {
+    private fun getHeaders(manga: Manga, source: HttpSource?): Headers {
         if (source == null) return LazyHeaders.DEFAULT
 
         return cachedHeaders.getOrPut(manga.source) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaThumbnailModelLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaThumbnailModelLoader.kt
@@ -83,10 +83,10 @@ class MangaThumbnailModelLoader : ModelLoader<MangaThumbnail, InputStream> {
      * @param height the height of the view where the resource will be loaded.
      */
     override fun buildLoadData(
-            mangaThumbnail: MangaThumbnail,
-            width: Int,
-            height: Int,
-            options: Options
+        mangaThumbnail: MangaThumbnail,
+        width: Int,
+        height: Int,
+        options: Options
     ): ModelLoader.LoadData<InputStream>? {
         // Check thumbnail is not null or empty
         val url = mangaThumbnail.url

--- a/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaThumbnailModelLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/glide/MangaThumbnailModelLoader.kt
@@ -96,7 +96,7 @@ class MangaThumbnailModelLoader : ModelLoader<MangaThumbnail, InputStream> {
 
         val manga = mangaThumbnail.manga
 
-        if (url.startsWith("http")) {
+        if (url.startsWith("http", true)) {
             val source = sourceManager.get(manga.source) as? HttpSource
             val glideUrl = GlideUrl(url, getHeaders(manga, source))
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/glide/TachiGlideModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/glide/TachiGlideModule.kt
@@ -13,7 +13,6 @@ import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.module.AppGlideModule
 import com.bumptech.glide.request.RequestOptions
-import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.network.NetworkHelper
 import java.io.InputStream
 import uy.kohesive.injekt.Injekt
@@ -36,7 +35,7 @@ class TachiGlideModule : AppGlideModule() {
         val networkFactory = OkHttpUrlLoader.Factory(Injekt.get<NetworkHelper>().client)
 
         registry.replace(GlideUrl::class.java, InputStream::class.java, networkFactory)
-        registry.append(Manga::class.java, InputStream::class.java, MangaModelLoader.Factory())
+        registry.append(MangaThumbnail::class.java, InputStream::class.java, MangaThumbnailModelLoader.Factory())
         registry.append(InputStream::class.java, InputStream::class.java, PassthroughModelLoader
                 .Factory())
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateService.kt
@@ -22,6 +22,7 @@ import eu.kanade.tachiyomi.data.database.models.LibraryManga
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadService
+import eu.kanade.tachiyomi.data.glide.toMangaThumbnail
 import eu.kanade.tachiyomi.data.library.LibraryUpdateRanker.rankingScheme
 import eu.kanade.tachiyomi.data.library.LibraryUpdateService.Companion.start
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
@@ -557,7 +558,7 @@ class LibraryUpdateService(
         return try {
             Glide.with(this)
                     .asBitmap()
-                    .load(manga)
+                    .load(manga.toMangaThumbnail())
                     .dontTransform()
                     .centerCrop()
                     .circleCrop()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryGridHolder.kt
@@ -4,6 +4,7 @@ import android.view.View
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.kanade.tachiyomi.data.glide.GlideApp
+import eu.kanade.tachiyomi.data.glide.toMangaThumbnail
 import eu.kanade.tachiyomi.source.LocalSource
 import eu.kanade.tachiyomi.util.view.visibleIf
 import kotlinx.android.synthetic.main.source_grid_item.download_text
@@ -52,7 +53,7 @@ class LibraryGridHolder(
         // Update the cover.
         GlideApp.with(view.context).clear(thumbnail)
         GlideApp.with(view.context)
-                .load(item.manga)
+                .load(item.manga.toMangaThumbnail())
                 .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                 .centerCrop()
                 .into(thumbnail)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryListHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryListHolder.kt
@@ -4,6 +4,7 @@ import android.view.View
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.kanade.tachiyomi.data.glide.GlideApp
+import eu.kanade.tachiyomi.data.glide.toMangaThumbnail
 import eu.kanade.tachiyomi.source.LocalSource
 import eu.kanade.tachiyomi.util.view.visibleIf
 import kotlinx.android.synthetic.main.source_list_item.download_text
@@ -59,7 +60,7 @@ class LibraryListHolder(
         // Update the cover.
         GlideApp.with(itemView.context).clear(thumbnail)
         GlideApp.with(itemView.context)
-                .load(item.manga)
+                .load(item.manga.toMangaThumbnail())
                 .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                 .centerCrop()
                 .circleCrop()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -62,6 +62,8 @@ class MangaInfoController(private val fromSource: Boolean = false) :
 
     private var initialLoad: Boolean = true
 
+    private var thumbnailUrl: String? = null
+
     override fun createPresenter(): MangaInfoPresenter {
         val ctrl = parentController as MangaController
         return MangaInfoPresenter(ctrl.manga!!, ctrl.source!!, ctrl.mangaFavoriteRelay)
@@ -225,7 +227,8 @@ class MangaInfoController(private val fromSource: Boolean = false) :
         setFavoriteButtonState(manga.favorite)
 
         // Set cover if it wasn't already.
-        if (binding.mangaCover.drawable == null && !manga.thumbnail_url.isNullOrEmpty()) {
+        if (binding.mangaCover.drawable == null || manga.thumbnail_url != thumbnailUrl) {
+            thumbnailUrl = manga.thumbnail_url
             val mangaThumbnail = manga.toMangaThumbnail()
 
             GlideApp.with(view.context)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoController.kt
@@ -16,6 +16,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.glide.GlideApp
+import eu.kanade.tachiyomi.data.glide.toMangaThumbnail
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.databinding.MangaInfoControllerBinding
 import eu.kanade.tachiyomi.source.Source
@@ -225,14 +226,16 @@ class MangaInfoController(private val fromSource: Boolean = false) :
 
         // Set cover if it wasn't already.
         if (binding.mangaCover.drawable == null && !manga.thumbnail_url.isNullOrEmpty()) {
+            val mangaThumbnail = manga.toMangaThumbnail()
+
             GlideApp.with(view.context)
-                    .load(manga)
+                    .load(mangaThumbnail)
                     .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                     .centerCrop()
                     .into(binding.mangaCover)
 
             GlideApp.with(view.context)
-                    .load(manga)
+                    .load(mangaThumbnail)
                     .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                     .centerCrop()
                     .into(binding.backdrop)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/MangaHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/MangaHolder.kt
@@ -4,6 +4,7 @@ import android.view.View
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.kanade.tachiyomi.data.glide.GlideApp
+import eu.kanade.tachiyomi.data.glide.toMangaThumbnail
 import eu.kanade.tachiyomi.ui.base.holder.BaseFlexibleViewHolder
 import kotlinx.android.synthetic.main.source_list_item.thumbnail
 import kotlinx.android.synthetic.main.source_list_item.title
@@ -26,7 +27,7 @@ class MangaHolder(
         // Update the cover.
         GlideApp.with(itemView.context).clear(thumbnail)
         GlideApp.with(itemView.context)
-                .load(item.manga)
+                .load(item.manga.toMangaThumbnail())
                 .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                 .centerCrop()
                 .circleCrop()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -411,7 +411,7 @@ class PagerPageHolder(
         }
 
         val imageUrl = page.imageUrl
-        if (imageUrl.orEmpty().startsWith("http")) {
+        if (imageUrl.orEmpty().startsWith("http", true)) {
             PagerButton(context, viewer).apply {
                 layoutParams = LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
                     setMargins(margins, margins, margins, margins)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -454,7 +454,7 @@ class WebtoonPageHolder(
         }
 
         val imageUrl = page?.imageUrl
-        if (imageUrl.orEmpty().startsWith("http")) {
+        if (imageUrl.orEmpty().startsWith("http", true)) {
             AppCompatButton(context).apply {
                 layoutParams = FrameLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
                     setMargins(0, margins, 0, margins)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/history/HistoryHolder.kt
@@ -5,6 +5,7 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.MangaChapterHistory
 import eu.kanade.tachiyomi.data.glide.GlideApp
+import eu.kanade.tachiyomi.data.glide.toMangaThumbnail
 import eu.kanade.tachiyomi.ui.base.holder.BaseFlexibleViewHolder
 import eu.kanade.tachiyomi.util.lang.toTimestampString
 import java.util.Date
@@ -67,7 +68,7 @@ class HistoryHolder(
         GlideApp.with(itemView.context).clear(cover)
         if (!manga.thumbnail_url.isNullOrEmpty()) {
             GlideApp.with(itemView.context)
-                    .load(manga)
+                    .load(manga.toMangaThumbnail())
                     .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                     .centerCrop()
                     .into(cover)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesHolder.kt
@@ -6,6 +6,7 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.glide.GlideApp
+import eu.kanade.tachiyomi.data.glide.toMangaThumbnail
 import eu.kanade.tachiyomi.ui.base.holder.BaseFlexibleViewHolder
 import eu.kanade.tachiyomi.util.system.getResourceColor
 import kotlinx.android.synthetic.main.updates_item.chapter_title
@@ -58,7 +59,7 @@ class UpdatesHolder(private val view: View, private val adapter: UpdatesAdapter)
         GlideApp.with(itemView.context).clear(manga_cover)
         if (!item.manga.thumbnail_url.isNullOrEmpty()) {
             GlideApp.with(itemView.context)
-                    .load(item.manga)
+                    .load(item.manga.toMangaThumbnail())
                     .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                     .circleCrop()
                     .into(manga_cover)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/SourceGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/SourceGridHolder.kt
@@ -5,6 +5,7 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.glide.GlideApp
+import eu.kanade.tachiyomi.data.glide.toMangaThumbnail
 import eu.kanade.tachiyomi.widget.StateImageViewTarget
 import kotlinx.android.synthetic.main.source_grid_item.progress
 import kotlinx.android.synthetic.main.source_grid_item.thumbnail
@@ -41,7 +42,7 @@ class SourceGridHolder(private val view: View, private val adapter: FlexibleAdap
         GlideApp.with(view.context).clear(thumbnail)
         if (!manga.thumbnail_url.isNullOrEmpty()) {
             GlideApp.with(view.context)
-                    .load(manga)
+                    .load(manga.toMangaThumbnail())
                     .diskCacheStrategy(DiskCacheStrategy.DATA)
                     .centerCrop()
                     .placeholder(android.R.color.transparent)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/SourceListHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/SourceListHolder.kt
@@ -7,6 +7,7 @@ import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.glide.GlideApp
+import eu.kanade.tachiyomi.data.glide.toMangaThumbnail
 import eu.kanade.tachiyomi.util.system.getResourceColor
 import kotlinx.android.synthetic.main.source_list_item.thumbnail
 import kotlinx.android.synthetic.main.source_list_item.title
@@ -42,7 +43,7 @@ class SourceListHolder(private val view: View, adapter: FlexibleAdapter<*>) :
         GlideApp.with(view.context).clear(thumbnail)
         if (!manga.thumbnail_url.isNullOrEmpty()) {
             GlideApp.with(view.context)
-                    .load(manga)
+                    .load(manga.toMangaThumbnail())
                     .diskCacheStrategy(DiskCacheStrategy.DATA)
                     .centerCrop()
                     .circleCrop()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/global_search/GlobalSearchCardHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/global_search/GlobalSearchCardHolder.kt
@@ -4,6 +4,7 @@ import android.view.View
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.glide.GlideApp
+import eu.kanade.tachiyomi.data.glide.toMangaThumbnail
 import eu.kanade.tachiyomi.ui.base.holder.BaseFlexibleViewHolder
 import eu.kanade.tachiyomi.widget.StateImageViewTarget
 import kotlinx.android.synthetic.main.global_search_controller_card_item.itemImage
@@ -42,7 +43,7 @@ class GlobalSearchCardHolder(view: View, adapter: GlobalSearchCardAdapter) :
         GlideApp.with(itemView.context).clear(itemImage)
         if (!manga.thumbnail_url.isNullOrEmpty()) {
             GlideApp.with(itemView.context)
-                    .load(manga)
+                    .load(manga.toMangaThumbnail())
                     .diskCacheStrategy(DiskCacheStrategy.DATA)
                     .centerCrop()
                     .skipMemoryCache(true)


### PR DESCRIPTION
Fixes #2894 

Problem was in two places. First, `MangaInfoController` only requested reload if the image is null, so refreshing is not possible since the image would've already been set.

Secondly, Glide uses mem and disk caches. There's already code like the `MangaSignature` class that handles the disk cache. But the mem caches use the `equals()/hashCode()` methods of the model, in this case `Manga`, which only compares the manga's url. So even when the thumbnail url has been updated, glide would not reload the image until it is evicted from the cache (which happens after restarting the app among other things).

The model loader now takes in a wrapper `MangaThumbnail` which also checks the thumbnail url for equality.

Also made some `url.startsWith("http")` checks case insensitive.