### PR TITLE
Replace TextDrawable with a Kotlin fork

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -219,7 +219,7 @@ dependencies {
     implementation 'eu.davidea:flexible-adapter:5.1.0'
     implementation 'eu.davidea:flexible-adapter-ui:1.0.0'
     implementation 'com.nononsenseapps:filepicker:2.5.2'
-    implementation 'com.github.amulyakhare:TextDrawable:558677e'
+    implementation 'com.github.Kennyc1012:TextDrawable:2.0.1'
     implementation 'com.nightlynexus.viewstatepageradapter:viewstatepageradapter:1.1.0'
     implementation 'com.github.mthli:Slice:v1.3'
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,7 +126,7 @@ dependencies {
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    implementation 'androidx.preference:preference:1.1.0'
+    implementation 'androidx.preference:preference:1.1.1'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.browser:browser:1.2.0'
     implementation 'androidx.multidex:multidex:2.0.1'

--- a/app/src/main/java/eu/kanade/tachiyomi/util/view/ViewExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/view/ViewExtensions.kt
@@ -14,10 +14,10 @@ import android.widget.TextView
 import androidx.annotation.MenuRes
 import androidx.appcompat.widget.PopupMenu
 import androidx.recyclerview.widget.RecyclerView
-import com.amulyakhare.textdrawable.TextDrawable
-import com.amulyakhare.textdrawable.util.ColorGenerator
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import com.google.android.material.snackbar.Snackbar
+import com.kennyc.textdrawable.ColorGenerator
+import com.kennyc.textdrawable.TextDrawable
 import eu.kanade.tachiyomi.R
 import kotlin.math.min
 
@@ -93,11 +93,14 @@ fun ImageView.roundTextIcon(text: String) {
     val letter = text.take(1).toUpperCase()
     val size = min(this.width, this.height)
 
-    setImageDrawable(
-        TextDrawable.builder().beginConfig().width(size).height(size).textColor(Color.WHITE)
-            .useFont(Typeface.DEFAULT).endConfig().buildRound(
-                letter, ColorGenerator.MATERIAL.getColor(letter)
-            )
+    TextDrawable(
+            shape = TextDrawable.DRAWABLE_SHAPE_OVAL,
+            desiredWidth = size,
+            desiredHeight = size,
+            typeFace = Typeface.DEFAULT,
+            textColor = Color.WHITE,
+            text = letter,
+            color = ColorGenerator.MATERIAL.getColor(letter)
     )
 }
 


### PR DESCRIPTION
@Kennyc1012 has rewritten the old dead library into Kotlin (thanks!) with simplifications and some features. I hope you don't mind :) https://github.com/Kennyc1012/TextDrawable

I built an APK with the changes and couldn't find any bugs related to it, so I think it's probably good (or I'm just a terrible bug-finder).

Also bumped AndroidX Preferences 1.1.0 to 1.1.1.