### PR TITLE
Pull basic manga/chapter metadata from EPUB files.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/storage/EpubFile.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/storage/EpubFile.kt
@@ -89,7 +89,7 @@ class EpubFile(file: File) : Closeable {
         }
 
         if (date != null) {
-            val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.getDefault())
+            val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault())
             try {
                 val parsedDate = dateFormat.parse(date.text())
                 if (parsedDate != null) {


### PR DESCRIPTION
Follow-up to my previous pull request for some additional EPUB enhancements.

Pulls the following information from the first chapter for local manga:
* Author
* Description

Pulls the following information for each chapter:
* Title
* Scanlator (Set to Publisher if found, otherwise Creator)
* Publication Date

Also contains code to fuzzy-match manga titles to remove them from chapter names, for cases in which a manga's title within chapter metadata contains characters that can't be represented in the manga directory name.