### PR TITLE
Cover Update Followup to Address #3139

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -34,6 +34,7 @@ import eu.kanade.tachiyomi.ui.base.controller.withFadeTransaction
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.main.offsetAppbarHeight
 import eu.kanade.tachiyomi.ui.manga.MangaController
+import eu.kanade.tachiyomi.util.hasCustomCover
 import eu.kanade.tachiyomi.util.system.getResourceColor
 import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.view.visible
@@ -487,7 +488,7 @@ class LibraryController(
     private fun handleChangeCover() {
         val manga = selectedMangas.firstOrNull() ?: return
 
-        if (coverCache.getCustomCoverFile(manga).exists()) {
+        if (manga.hasCustomCover(coverCache)) {
             showEditCoverDialog(manga)
         } else {
             openMangaCoverPicker(manga)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/info/MangaInfoPresenter.kt
@@ -75,9 +75,7 @@ class MangaInfoPresenter(
         if (!fetchMangaSubscription.isNullOrUnsubscribed()) return
         fetchMangaSubscription = Observable.defer { source.fetchMangaDetails(manga) }
             .map { networkManga ->
-                if (manualFetch || manga.thumbnail_url != networkManga.thumbnail_url) {
-                    manga.prepUpdateCover(coverCache)
-                }
+                manga.prepUpdateCover(coverCache, networkManga, manualFetch)
                 manga.copyFrom(networkManga)
                 manga.initialized = true
                 db.insertManga(manga).executeAsBlocking()

--- a/app/src/main/java/eu/kanade/tachiyomi/util/MangaExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/MangaExtensions.kt
@@ -4,6 +4,7 @@ import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.source.LocalSource
+import eu.kanade.tachiyomi.source.model.SManga
 import java.util.Date
 
 fun Manga.isLocal() = source == LocalSource.ID
@@ -11,12 +12,25 @@ fun Manga.isLocal() = source == LocalSource.ID
 /**
  * Call before updating [Manga.thumbnail_url] to ensure old cover can be cleared from cache
  */
-fun Manga.prepUpdateCover(coverCache: CoverCache) {
-    cover_last_modified = Date().time
+fun Manga.prepUpdateCover(coverCache: CoverCache, remoteManga: SManga, refreshSameUrl: Boolean) {
+    // Never refresh covers if the new url is null, as the current url has possibly become invalid
+    val newUrl = remoteManga.thumbnail_url ?: return
 
-    if (!isLocal()) {
-        coverCache.deleteFromCache(this, false)
+    if (!refreshSameUrl && thumbnail_url == newUrl) return
+
+    when {
+        isLocal() -> {
+            cover_last_modified = Date().time
+        }
+        !hasCustomCover(coverCache) -> {
+            cover_last_modified = Date().time
+            coverCache.deleteFromCache(this, false)
+        }
     }
+}
+
+fun Manga.hasCustomCover(coverCache: CoverCache): Boolean {
+    return coverCache.getCustomCoverFile(this).exists()
 }
 
 fun Manga.removeCovers(coverCache: CoverCache) {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/MangaExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/MangaExtensions.kt
@@ -22,7 +22,10 @@ fun Manga.prepUpdateCover(coverCache: CoverCache, remoteManga: SManga, refreshSa
         isLocal() -> {
             cover_last_modified = Date().time
         }
-        !hasCustomCover(coverCache) -> {
+        hasCustomCover(coverCache) -> {
+            coverCache.deleteFromCache(this, false)
+        }
+        else -> {
             cover_last_modified = Date().time
             coverCache.deleteFromCache(this, false)
         }


### PR DESCRIPTION
https://github.com/inorichi/tachiyomi/issues/3139

My PR actually potentially causes this kind of issue, since even though the thumbnail url won't get set to null, the local cover file will still be deleted. And it's possible the current url is no longer valid. Added some additional logic to prevent that from happening.

Not sure what happened in the original issue though, since my PR hadn't even been merged yet. My guess it was just a networking error with fetching the new url.