### PR TITLE
fix regular font family name

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -48,7 +48,7 @@
     </style>
 
     <style name="TextAppearance.Regular">
-        <item name="android:fontFamily">sans-serif-regular</item>
+        <item name="android:fontFamily">sans-serif</item>
     </style>
 
     <style name="TextAppearance.Regular.Body1">


### PR DESCRIPTION
Weird how nobody's noticed this issue yet 🤔  

<details>

![](http://puu.sh/FIVGq/6fefb46115.png)

![](http://puu.sh/FIVPA/07943e86bd.png)

</details>
