### PR TITLE
Added sorting chapters by upload date

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
@@ -78,7 +78,8 @@ interface Manga : SManga {
 
         const val SORTING_SOURCE = 0x00000000
         const val SORTING_NUMBER = 0x00000100
-        const val SORTING_MASK = 0x00000100
+        const val SORTING_UPLOAD_DATE = 0x00000200
+        const val SORTING_MASK = 0x00000300
 
         const val DISPLAY_NAME = 0x00000000
         const val DISPLAY_NUMBER = 0x00100000

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
@@ -196,11 +196,13 @@ class ChaptersController :
         }
 
         // Sorting mode submenu
-        if (presenter.manga.sorting == Manga.SORTING_SOURCE) {
-            menu.findItem(R.id.sort_by_source).isChecked = true
-        } else {
-            menu.findItem(R.id.sort_by_number).isChecked = true
+        val sortingItem = when (presenter.manga.sorting) {
+            Manga.SORTING_SOURCE -> R.id.sort_by_source
+            Manga.SORTING_NUMBER -> R.id.sort_by_number
+            Manga.SORTING_UPLOAD_DATE -> R.id.sort_by_upload_date
+            else -> throw NotImplementedError("Unimplemented sorting method")
         }
+        menu.findItem(sortingItem).isChecked = true
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -221,6 +223,10 @@ class ChaptersController :
             R.id.sort_by_number -> {
                 item.isChecked = true
                 presenter.setSorting(Manga.SORTING_NUMBER)
+            }
+            R.id.sort_by_upload_date -> {
+                item.isChecked = true
+                presenter.setSorting(Manga.SORTING_UPLOAD_DATE)
             }
 
             R.id.download_next, R.id.download_next_5, R.id.download_next_10,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersPresenter.kt
@@ -203,6 +203,10 @@ class ChaptersPresenter(
                 true -> { c1, c2 -> c2.chapter_number.compareTo(c1.chapter_number) }
                 false -> { c1, c2 -> c1.chapter_number.compareTo(c2.chapter_number) }
             }
+            Manga.SORTING_UPLOAD_DATE -> when (sortDescending()) {
+                true -> { c1, c2 -> c2.date_upload.compareTo(c1.date_upload) }
+                false -> { c1, c2 -> c1.date_upload.compareTo(c2.date_upload) }
+            }
             else -> throw NotImplementedError("Unimplemented sorting method")
         }
         return observable.toSortedList(sortFunction)

--- a/app/src/main/res/menu/chapters.xml
+++ b/app/src/main/res/menu/chapters.xml
@@ -64,6 +64,9 @@
                 <item
                     android:id="@+id/sort_by_number"
                     android:title="@string/sort_by_number" />
+                <item
+                    android:id="@+id/sort_by_upload_date"
+                    android:title="@string/sort_by_upload_date" />
             </group>
         </menu>
     </item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -183,6 +183,7 @@
     <string name="sorting_mode">Ordenado de capítulos</string>
     <string name="sort_by_source">Por fuente</string>
     <string name="sort_by_number">Por número de capítulo</string>
+    <string name="sort_by_upload_date">Por fecha de carga</string>
     <string name="manga_download">Descargar</string>
     <string name="download_1">Siguiente capítulo</string>
     <string name="download_5">Siguientes 5 capítulos</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -473,6 +473,7 @@
     <string name="sorting_mode">Sorting mode</string>
     <string name="sort_by_source">By source</string>
     <string name="sort_by_number">By chapter number</string>
+    <string name="sort_by_upload_date">By chapter upload date</string>
     <string name="manga_download">Download</string>
     <string name="custom_download">Download custom amount</string>
     <string name="download_1">Next chapter</string>


### PR DESCRIPTION
Solves #1962. Spanish `strings.xml` contains the proper translation for the new feature.

---

A few things as a first-time contributor:

- Handling masks is a real pain when it comes to adding new features. I guess this is done for performance reasons or for easier serialization, but it's actually necessary?
https://github.com/inorichi/tachiyomi/blob/8a4c4c346ab8f23fbe3e12d091ad291cbb0dcc7c/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt#L58-L85

- The sorting selection function for chapters redefines each function if the order is ascending/descending, requiring code duplication:
https://github.com/inorichi/tachiyomi/blob/cac11f8be4b67f23670bceb9f9a5326cf271bd80/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersPresenter.kt#L197-L210