### PR TITLE
download new chapters changes

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
@@ -99,7 +99,7 @@ class ChaptersController :
         adapter?.fastScroller = binding.fastScroller
 
         binding.swipeRefresh.refreshes()
-            .onEach { fetchChaptersFromSource() }
+            .onEach { fetchChaptersFromSource(manualFetch = true) }
             .launchIn(scope)
 
         binding.fab.clicks()
@@ -257,11 +257,7 @@ class ChaptersController :
     }
 
     fun onNextChapters(chapters: List<ChapterItem>) {
-        // If the list is empty, fetch chapters from source if the conditions are met
-        // We use presenter chapters instead because they are always unfiltered
-        if (presenter.chapters.isEmpty()) {
-            initialFetchChapters()
-        }
+        initialFetchChapters()
 
         val adapter = adapter ?: return
         adapter.updateDataSet(chapters)
@@ -280,15 +276,16 @@ class ChaptersController :
     }
 
     private fun initialFetchChapters() {
-        // Only fetch if this view is from the catalog and it hasn't requested previously
-        if ((parentController as MangaController).fromSource && !presenter.hasRequested) {
+        // If the list is empty and it hasn't requested previously, fetch chapters from source
+        // We use presenter chapters instead because they are always unfiltered
+        if (!presenter.hasRequested && presenter.chapters.isEmpty()) {
             fetchChaptersFromSource()
         }
     }
 
-    private fun fetchChaptersFromSource() {
+    private fun fetchChaptersFromSource(manualFetch: Boolean = false) {
         binding.swipeRefresh.isRefreshing = true
-        presenter.fetchChaptersFromSource()
+        presenter.fetchChaptersFromSource(manualFetch)
     }
 
     fun onFetchChaptersDone() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersController.kt
@@ -257,7 +257,11 @@ class ChaptersController :
     }
 
     fun onNextChapters(chapters: List<ChapterItem>) {
-        initialFetchChapters()
+        // If the list is empty and it hasn't requested previously, fetch chapters from source
+        // We use presenter chapters instead because they are always unfiltered
+        if (!presenter.hasRequested && presenter.chapters.isEmpty()) {
+            fetchChaptersFromSource()
+        }
 
         val adapter = adapter ?: return
         adapter.updateDataSet(chapters)
@@ -272,14 +276,6 @@ class ChaptersController :
                 }
             }
             actionMode?.invalidate()
-        }
-    }
-
-    private fun initialFetchChapters() {
-        // If the list is empty and it hasn't requested previously, fetch chapters from source
-        // We use presenter chapters instead because they are always unfiltered
-        if (!presenter.hasRequested && presenter.chapters.isEmpty()) {
-            fetchChaptersFromSource()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersPresenter.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.ui.base.presenter.BasePresenter
 import eu.kanade.tachiyomi.util.chapter.syncChaptersWithSource
 import eu.kanade.tachiyomi.util.isLocal
 import eu.kanade.tachiyomi.util.lang.isNullOrUnsubscribed
+import eu.kanade.tachiyomi.util.shouldDownloadNewChapters
 import java.util.Date
 import rx.Observable
 import rx.Subscription
@@ -153,13 +154,18 @@ class ChaptersPresenter(
     /**
      * Requests an updated list of chapters from the source.
      */
-    fun fetchChaptersFromSource() {
+    fun fetchChaptersFromSource(manualFetch: Boolean = false) {
         hasRequested = true
 
         if (!fetchChaptersSubscription.isNullOrUnsubscribed()) return
         fetchChaptersSubscription = Observable.defer { source.fetchChapterList(manga) }
             .subscribeOn(Schedulers.io())
             .map { syncChaptersWithSource(db, it, manga, source) }
+            .doOnNext {
+                if (manualFetch) {
+                    downloadNewChapters(it.first)
+                }
+            }
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeFirst(
                 { view, _ ->
@@ -258,7 +264,7 @@ class ChaptersPresenter(
      * Downloads the given list of chapters with the manager.
      * @param chapters the list of chapters to download.
      */
-    fun downloadChapters(chapters: List<ChapterItem>) {
+    fun downloadChapters(chapters: List<Chapter>) {
         downloadManager.downloadChapters(manga, chapters)
     }
 
@@ -293,6 +299,12 @@ class ChaptersPresenter(
                 },
                 ChaptersController::onChaptersDeletedError
             )
+    }
+
+    private fun downloadNewChapters(chapters: List<Chapter>) {
+        if (chapters.isEmpty() || !manga.shouldDownloadNewChapters(db, preferences)) return
+
+        downloadChapters(chapters)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/util/MangaExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/MangaExtensions.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.util
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.source.LocalSource
 import eu.kanade.tachiyomi.source.model.SManga
 import java.util.Date
@@ -46,4 +47,18 @@ fun Manga.removeCovers(coverCache: CoverCache) {
 fun Manga.updateCoverLastModified(db: DatabaseHelper) {
     cover_last_modified = Date().time
     db.updateMangaCoverLastModified(this).executeAsBlocking()
+}
+
+fun Manga.shouldDownloadNewChapters(db: DatabaseHelper, prefs: PreferencesHelper): Boolean {
+    // Boolean to determine if user wants to automatically download new chapters.
+    val downloadNew = prefs.downloadNew().get()
+
+    val categoriesToDownload = prefs.downloadNewCategories().get().map(String::toInt)
+
+    val categoriesForManga by lazy {
+        db.getCategoriesForManga(this).executeAsBlocking().mapNotNull { it.id }
+    }
+
+    return downloadNew &&
+        (categoriesToDownload.isEmpty() || categoriesForManga.intersect(categoriesToDownload).isNotEmpty())
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/MangaExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/MangaExtensions.kt
@@ -52,13 +52,12 @@ fun Manga.updateCoverLastModified(db: DatabaseHelper) {
 fun Manga.shouldDownloadNewChapters(db: DatabaseHelper, prefs: PreferencesHelper): Boolean {
     // Boolean to determine if user wants to automatically download new chapters.
     val downloadNew = prefs.downloadNew().get()
+    if (!downloadNew) return false
 
     val categoriesToDownload = prefs.downloadNewCategories().get().map(String::toInt)
+    if (categoriesToDownload.isEmpty()) return true
 
-    val categoriesForManga by lazy {
-        db.getCategoriesForManga(this).executeAsBlocking().mapNotNull { it.id }
-    }
+    val categoriesForManga = db.getCategoriesForManga(this).executeAsBlocking().mapNotNull { it.id }
 
-    return downloadNew &&
-        (categoriesToDownload.isEmpty() || categoriesForManga.intersect(categoriesToDownload).isNotEmpty())
+    return categoriesForManga.intersect(categoriesToDownload).isNotEmpty()
 }


### PR DESCRIPTION
Closes #3168 
Fixes #2325

Also some other related changes

- Fix bug with library updates where new chapters do not download if the manga is in multiple categories and download categories are specified.

- Allow auto initial chapters fetch on `ChaptersController` when not navigating from browse source.