### PR TITLE
Rename downloaded chapters

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
@@ -3,11 +3,14 @@ package eu.kanade.tachiyomi.util.chapter
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.online.HttpSource
 import java.util.Date
 import java.util.TreeSet
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 /**
  * Helper method for syncing the list of chapters from the source with the ones from the database.
@@ -27,6 +30,8 @@ fun syncChaptersWithSource(
     if (rawSourceChapters.isEmpty()) {
         throw Exception("No chapters found")
     }
+
+    val downloadManager: DownloadManager = Injekt.get()
 
     // Chapters from db.
     val dbChapters = db.getChapters(manga).executeAsBlocking()
@@ -60,6 +65,9 @@ fun syncChaptersWithSource(
             ChapterRecognition.parseChapterNumber(sourceChapter, manga)
 
             if (shouldUpdateDbChapter(dbChapter, sourceChapter)) {
+                if (dbChapter.name != sourceChapter.name && downloadManager.isChapterDownloaded(dbChapter, manga)) {
+                    downloadManager.renameChapter(source, manga, dbChapter, sourceChapter)
+                }
                 dbChapter.scanlator = sourceChapter.scanlator
                 dbChapter.name = sourceChapter.name
                 dbChapter.date_upload = sourceChapter.date_upload


### PR DESCRIPTION
This renames downloaded chapters when the chapter names change on the source, because it is very annoying to have all of my downloads disappear as soon as volume numbers or chapter titles are added.

Addresses #1338, so long as the chapter's url stays the same.