### PR TITLE
Text Input Improvements

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/widget/preference/LoginDialogPreference.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/widget/preference/LoginDialogPreference.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.widget.preference
 
 import android.app.Dialog
 import android.os.Bundle
-import android.text.method.PasswordTransformationMethod
 import android.view.View
 import androidx.annotation.StringRes
 import com.afollestad.materialdialogs.MaterialDialog
@@ -14,8 +13,6 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.ui.base.controller.DialogController
 import kotlinx.android.synthetic.main.pref_account_login.view.login
-import kotlinx.android.synthetic.main.pref_account_login.view.password
-import kotlinx.android.synthetic.main.pref_account_login.view.show_password
 import kotlinx.android.synthetic.main.pref_account_login.view.username_label
 import rx.Subscription
 import uy.kohesive.injekt.injectLazy
@@ -50,14 +47,6 @@ abstract class LoginDialogPreference(
 
     fun onViewCreated(view: View) {
         v = view.apply {
-            show_password.setOnCheckedChangeListener { _, isChecked ->
-                if (isChecked) {
-                    password.transformationMethod = null
-                } else {
-                    password.transformationMethod = PasswordTransformationMethod()
-                }
-            }
-
             if (usernameLabelRes != null) {
                 username_label.hint = context.getString(usernameLabelRes)
             }

--- a/app/src/main/res/layout/pref_account_login.xml
+++ b/app/src/main/res/layout/pref_account_login.xml
@@ -16,30 +16,24 @@
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/username"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:inputType="text" />
 
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/password">
+        android:hint="@string/password"
+        app:endIconMode="password_toggle">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/password"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:ems="10"
             android:inputType="textPassword" />
 
     </com.google.android.material.textfield.TextInputLayout>
-
-    <CheckBox
-        android:id="@+id/show_password"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:text="@string/show_password" />
 
     <com.dd.processbutton.iml.ActionProcessButton
         android:id="@+id/login"

--- a/app/src/main/res/layout/track_search_dialog.xml
+++ b/app/src/main/res/layout/track_search_dialog.xml
@@ -1,19 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <EditText
-        android:id="@+id/track_search"
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:hint="@string/title"
-        android:inputType="text"
-        android:maxLines="1" />
+        app:boxBackgroundMode="filled"
+        app:endIconMode="clear_text"
+        app:hintEnabled="false">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/track_search"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/title"
+            android:inputType="text" />
+
+    </com.google.android.material.textfield.TextInputLayout>
 
     <FrameLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
1. Use material password toggle icon for track login.

2. Use material for track search for enabling the clear text button. Useful for clearing out long manga names when search fails. Opted to keep the UI similar (underline only).

<details>

![Screenshot_1590961977](https://user-images.githubusercontent.com/24946428/83363542-10557000-a34f-11ea-9701-d106272601a8.png)
![Screenshot_1590960958](https://user-images.githubusercontent.com/24946428/83363541-0f244300-a34f-11ea-808a-5e77621e5ac2.png)
![Screenshot_1590962056](https://user-images.githubusercontent.com/24946428/83363543-10557000-a34f-11ea-90ab-d738a6dc1d77.png)


</details>