### PR TITLE
Dirty "Fix" to issue #1561

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -330,7 +330,7 @@ class Downloader(
             return Observable.just(page)
         }
 
-        val filename = String.format("%03d", page.number)
+        val filename = String.format("%05d", page.number)
         val tmpFile = tmpDir.findFile("$filename.tmp")
 
         // Delete temp file if it exists.


### PR DESCRIPTION
"Fixes" the issue of the file name %03d in the download.kt that causes sorting problems if the chapter has more than 1k pics. I changed it to %05d since it's quite rare for pics to have more than 100k in 1 chapter (and is also a dirty quick fix :P).

_New to git and first-time pull request here, if I am doing anything wrong please correct me!_