### PR TITLE
Nth download tweak

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -666,7 +666,7 @@ class ReaderPresenter(
      * manager handles persisting it across process deaths.
      */
     private fun enqueueDeleteReadChapters(chapter: ReaderChapter) {
-        if (!chapter.chapter.read || chapter.pageLoader !is DownloadPageLoader) return
+        if (!chapter.chapter.read) return
         val manga = manga ?: return
 
         launchIO {


### PR DESCRIPTION
ignore fact that loader might not be downloadPageLoader.

This fixes the following:

lets say i have 3 chapters, all downloaded, chapter 1 and chapter 2 are marked read.
Nth is set to keep 2nd last read.
if i click on chapter 1 read it, continue into chapter 2 and read it.  continue into chapter 3 and read it
i back out to the chapter list
chapter 1 is deleted

now lets say same scenario but instead of clicking into chapter 1 i click into chapter 3.  I read it back out to the chapter list
chapter 1 is NOT deleted