### PR TITLE
Change sources sort to case-insensitive

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/details/ExtensionDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/details/ExtensionDetailsController.kt
@@ -112,7 +112,7 @@ class ExtensionDetailsController(bundle: Bundle? = null) :
                 .forEach {
                     val preferenceBlock = {
                         it.value
-                            .sortedWith(compareBy({ !it.isEnabled() }, { it.name }))
+                            .sortedWith(compareBy({ !it.isEnabled() }, { it.name.toLowerCase() }))
                             .forEach { source ->
                                 val sourcePrefs = mutableListOf<Preference>()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrationSourcesPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrationSourcesPresenter.kt
@@ -29,7 +29,7 @@ class MigrationSourcesPresenter(
         val header = SelectionHeader()
         return library.map { it.source }.toSet()
             .mapNotNull { if (it != LocalSource.ID) sourceManager.getOrStub(it) else null }
-            .sortedBy { it.name }
+            .sortedBy { it.name.toLowerCase() }
             .map { SourceItem(it, header) }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourceFilterController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourceFilterController.kt
@@ -42,7 +42,7 @@ class SourceFilterController : SettingsController() {
         )
 
         orderedLangs.forEach { lang ->
-            val sources = sourcesByLang[lang].orEmpty().sortedBy { it.name }
+            val sources = sourcesByLang[lang].orEmpty().sortedBy { it.name.toLowerCase() }
 
             // Create a preference group and set initial state and change listener
             switchPreferenceCategory {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcePresenter.kt
@@ -128,7 +128,7 @@ class SourcePresenter(
         return sourceManager.getCatalogueSources()
             .filter { it.lang in languages }
             .filterNot { it.id.toString() in disabledSourceIds }
-            .sortedBy { "(${it.lang}) ${it.name}" } +
+            .sortedBy { "(${it.lang}) ${it.name.toLowerCase()}" } +
             sourceManager.get(LocalSource.ID) as LocalSource
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchPresenter.kt
@@ -108,7 +108,7 @@ open class GlobalSearchPresenter(
         return sourceManager.getCatalogueSources()
             .filter { it.lang in languages }
             .filterNot { it.id.toString() in disabledSourceIds }
-            .sortedWith(compareBy({ it.id.toString() !in pinnedSourceIds }, { "${it.name} (${it.lang})" }))
+            .sortedWith(compareBy({ it.id.toString() !in pinnedSourceIds }, { "${it.name.toLowerCase()} (${it.lang})" }))
     }
 
     private fun getSourcesToQuery(): List<CatalogueSource> {
@@ -188,7 +188,7 @@ open class GlobalSearchPresenter(
                             { it.results.isNullOrEmpty() },
                             // Same as initial sort, i.e. pinned first then alphabetically
                             { it.source.id.toString() !in pinnedSourceIds },
-                            { "${it.source.name} (${it.source.lang})" }
+                            { "${it.source.name.toLowerCase()} (${it.source.lang})" }
                         )
                     )
             }


### PR DESCRIPTION
Extensions are sorted by something like `eu.kanade.tachiyomi.extension.all.mangadex` so it's already case-insensitive, but sources sorted by it's normal name like `MangaDex` so it's case-sensitive. I just added `toLowerCase()` in few places to make sort consistent for sources and extensions. In examples you can see that `Mangabat` was below `MangaTX` but now it's above `MangaBob`.

<details>
  <summary>How it was before</summary>

![before](https://user-images.githubusercontent.com/65343233/91869945-1ffe9080-ec7f-11ea-914c-6329092dd1ed.png)

</details>

<details>
  <summary>How it is in this PR</summary>
  
![after](https://user-images.githubusercontent.com/65343233/91870028-36a4e780-ec7f-11ea-9568-02f4fc1df6dd.png)

</details>

I did two changes in `GlobalSearchPresenter.kt`, I suppose that one is used when global search is initialized and second one to display results?