### PR TITLE
Darken the description colors

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChapterHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChapterHolder.kt
@@ -32,13 +32,19 @@ class ChapterHolder(
         }
 
         // Set correct text color
-        val chapterColor = when {
+        val chapterTitleColor = when {
             chapter.read -> adapter.readColor
             chapter.bookmark -> adapter.bookmarkedColor
             else -> adapter.unreadColor
         }
-        chapter_title.setTextColor(chapterColor)
-        chapter_description.setTextColor(chapterColor)
+        chapter_title.setTextColor(chapterTitleColor)
+
+        val chapterDescriptionColor = when {
+            chapter.read -> adapter.readColor
+            chapter.bookmark -> adapter.bookmarkedColor
+            else -> adapter.unreadColorSecondary
+        }
+        chapter_description.setTextColor(chapterDescriptionColor)
 
         bookmark_icon.isVisible = chapter.bookmark
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersAdapter.kt
@@ -22,6 +22,7 @@ class ChaptersAdapter(
 
     val readColor = context.getResourceColor(R.attr.colorOnSurface, 0.38f)
     val unreadColor = context.getResourceColor(R.attr.colorOnSurface)
+    val unreadColorSecondary = context.getResourceColor(R.attr.colorOnSurface, 0.62f)
 
     val bookmarkedColor = context.getResourceColor(R.attr.colorAccent)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/chapter/ChaptersAdapter.kt
@@ -22,7 +22,7 @@ class ChaptersAdapter(
 
     val readColor = context.getResourceColor(R.attr.colorOnSurface, 0.38f)
     val unreadColor = context.getResourceColor(R.attr.colorOnSurface)
-    val unreadColorSecondary = context.getResourceColor(R.attr.colorOnSurface, 0.62f)
+    val unreadColorSecondary = context.getResourceColor(android.R.attr.textColorSecondary)
 
     val bookmarkedColor = context.getResourceColor(R.attr.colorAccent)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesHolder.kt
@@ -31,7 +31,6 @@ class UpdatesHolder(private val view: View, private val adapter: UpdatesAdapter)
 
     private var readColor = view.context.getResourceColor(R.attr.colorOnSurface, 0.38f)
     private var unreadColor = view.context.getResourceColor(R.attr.colorOnSurface)
-    private var unreadColorSecondary = view.context.getResourceColor(R.attr.colorOnSurface, 0.62f)
 
     /**
      * Currently bound item.
@@ -63,7 +62,7 @@ class UpdatesHolder(private val view: View, private val adapter: UpdatesAdapter)
             chapter_title.setTextColor(readColor)
             manga_title.setTextColor(readColor)
         } else {
-            chapter_title.setTextColor(unreadColorSecondary)
+            chapter_title.setTextColor(unreadColor)
             manga_title.setTextColor(unreadColor)
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/recent/updates/UpdatesHolder.kt
@@ -31,6 +31,7 @@ class UpdatesHolder(private val view: View, private val adapter: UpdatesAdapter)
 
     private var readColor = view.context.getResourceColor(R.attr.colorOnSurface, 0.38f)
     private var unreadColor = view.context.getResourceColor(R.attr.colorOnSurface)
+    private var unreadColorSecondary = view.context.getResourceColor(R.attr.colorOnSurface, 0.62f)
 
     /**
      * Currently bound item.
@@ -62,7 +63,7 @@ class UpdatesHolder(private val view: View, private val adapter: UpdatesAdapter)
             chapter_title.setTextColor(readColor)
             manga_title.setTextColor(readColor)
         } else {
-            chapter_title.setTextColor(unreadColor)
+            chapter_title.setTextColor(unreadColorSecondary)
             manga_title.setTextColor(unreadColor)
         }
 


### PR DESCRIPTION
Darkens the description color on Manga Info page as well as the Updates view.
It closely matches the color of "DOWNLOADED", although that one was not a regular android attribute so couldn't figure out how to make `getResourceColor` to work for those.

`0.62f` value wasn't gotten organically from other colors, I tried finding something similiar but I thought that (`100`-`38`=`62`), `100` being unread, `38` being read, `62` now being sub-unread.

Feel free to grill me on this one but I felt <img src="https://cdn.discordapp.com/emojis/705791131694399540.png?v=1" alt="kannaKMS" width="32" height="32"> when looking at full white both texts... <img src="https://cdn.discordapp.com/emojis/742391272865661111.png?v=1?v=1" alt="vampySmug" width="32" height="32">

| Original | Edited |
| -------- | ------ |
| ![Original manga info](https://i.imgur.com/uGl8iLQ.png) | ![Edited manga info](https://i.imgur.com/XHsCR7i.png) |
| ![Original update list](https://i.imgur.com/K0mNgyo.png) | ![Edited update list](https://i.imgur.com/SS6aQ5c.png) |