### PR TITLE
Fix visual issue with bottom padding in filters sheet

### DIFF
--- a/app/src/main/res/layout/source_filter_sheet.xml
+++ b/app/src/main/res/layout/source_filter_sheet.xml
@@ -54,6 +54,8 @@
         android:layout_height="0dp"
         android:layout_gravity="top"
         android:layout_weight="1"
-        android:paddingBottom="8dp" />
+        android:paddingBottom="8dp"
+        android:clipChildren="false"
+        android:clipToPadding="false" />
 
 </LinearLayout>


### PR DESCRIPTION
Fixes #3854 

Padding in the bottom of the filters sheet is a bit wrong. This fixes it.

Before:
![image](https://user-images.githubusercontent.com/10186337/94894097-87099380-043d-11eb-877d-9ef9dfc8da29.png)

After:
![image](https://user-images.githubusercontent.com/10186337/94893970-40b43480-043d-11eb-9945-25e9f1131ed5.png)