### PR TITLE
Fix missing chapter warning when chapter number is not recognized

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/MissingChapters.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/MissingChapters.kt
@@ -16,6 +16,7 @@ fun hasMissingChapters(higher: Chapter?, lower: Chapter?): Boolean {
 }
 
 fun hasMissingChapters(higherChapterNumber: Float, lowerChapterNumber: Float): Boolean {
+    if (higherChapterNumber == 0f || lowerChapterNumber == 0f) return false
     return floor(higherChapterNumber) - floor(lowerChapterNumber) - 1f > 0f
 }
 
@@ -31,5 +32,6 @@ fun calculateChapterDifference(higher: Chapter?, lower: Chapter?): Float {
 }
 
 fun calculateChapterDifference(higherChapterNumber: Float, lowerChapterNumber: Float): Float {
+    if (higherChapterNumber == 0f || lowerChapterNumber == 0f) return 0f
     return floor(higherChapterNumber) - floor(lowerChapterNumber) - 1f
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/MissingChapters.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/MissingChapters.kt
@@ -1,15 +1,35 @@
 package eu.kanade.tachiyomi.ui.reader.viewer
 
 import eu.kanade.tachiyomi.data.database.models.Chapter
+import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import kotlin.math.floor
 
-object MissingChapters {
+fun hasMissingChapters(higher: ReaderChapter?, lower: ReaderChapter?): Boolean {
+    if (higher == null || lower == null) return false
+    return hasMissingChapters(higher.chapter, lower.chapter)
+}
 
-    fun hasMissingChapters(higher: Chapter, lower: Chapter): Boolean {
-        return hasMissingChapters(higher.chapter_number, lower.chapter_number)
-    }
+fun hasMissingChapters(higher: Chapter?, lower: Chapter?): Boolean {
+    if (higher == null || lower == null) return false
+    if (!higher.isRecognizedNumber || !lower.isRecognizedNumber) return false
+    return hasMissingChapters(higher.chapter_number, lower.chapter_number)
+}
 
-    fun hasMissingChapters(higherChapterNumber: Float, lowerChapterNumber: Float): Boolean {
-        return floor(higherChapterNumber) - floor(lowerChapterNumber) - 1f > 0f
-    }
+fun hasMissingChapters(higherChapterNumber: Float, lowerChapterNumber: Float): Boolean {
+    return floor(higherChapterNumber) - floor(lowerChapterNumber) - 1f > 0f
+}
+
+fun calculateChapterDifference(higher: ReaderChapter?, lower: ReaderChapter?): Float {
+    if (higher == null || lower == null) return 0f
+    return calculateChapterDifference(higher.chapter, lower.chapter)
+}
+
+fun calculateChapterDifference(higher: Chapter?, lower: Chapter?): Float {
+    if (higher == null || lower == null) return 0f
+    if (!higher.isRecognizedNumber || !lower.isRecognizedNumber) return 0f
+    return calculateChapterDifference(higher.chapter_number, lower.chapter_number)
+}
+
+fun calculateChapterDifference(higherChapterNumber: Float, lowerChapterNumber: Float): Float {
+    return floor(higherChapterNumber) - floor(lowerChapterNumber) - 1f
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/MissingChapters.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/MissingChapters.kt
@@ -4,34 +4,42 @@ import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import kotlin.math.floor
 
-fun hasMissingChapters(higher: ReaderChapter?, lower: ReaderChapter?): Boolean {
-    if (higher == null || lower == null) return false
-    return hasMissingChapters(higher.chapter, lower.chapter)
+private val pattern = Regex("""\d+""")
+
+fun hasMissingChapters(higherReaderChapter: ReaderChapter?, lowerReaderChapter: ReaderChapter?): Boolean {
+    if (higherReaderChapter == null || lowerReaderChapter == null) return false
+    return hasMissingChapters(higherReaderChapter.chapter, lowerReaderChapter.chapter)
 }
 
-fun hasMissingChapters(higher: Chapter?, lower: Chapter?): Boolean {
-    if (higher == null || lower == null) return false
-    if (!higher.isRecognizedNumber || !lower.isRecognizedNumber) return false
-    return hasMissingChapters(higher.chapter_number, lower.chapter_number)
+fun hasMissingChapters(higherChapter: Chapter?, lowerChapter: Chapter?): Boolean {
+    if (higherChapter == null || lowerChapter == null) return false
+    // Check if name contains a number that is potential chapter number
+    if (!pattern.containsMatchIn(higherChapter.name) || !pattern.containsMatchIn(lowerChapter.name)) return false
+    // Check if potential chapter number was recognized as chapter number
+    if (!higherChapter.isRecognizedNumber || !lowerChapter.isRecognizedNumber) return false
+    return hasMissingChapters(higherChapter.chapter_number, lowerChapter.chapter_number)
 }
 
 fun hasMissingChapters(higherChapterNumber: Float, lowerChapterNumber: Float): Boolean {
-    if (higherChapterNumber == 0f || lowerChapterNumber == 0f) return false
-    return floor(higherChapterNumber) - floor(lowerChapterNumber) - 1f > 0f
+    if (higherChapterNumber < 0f || lowerChapterNumber < 0f) return false
+    return calculateChapterDifference(higherChapterNumber, lowerChapterNumber) > 0f
 }
 
-fun calculateChapterDifference(higher: ReaderChapter?, lower: ReaderChapter?): Float {
-    if (higher == null || lower == null) return 0f
-    return calculateChapterDifference(higher.chapter, lower.chapter)
+fun calculateChapterDifference(higherReaderChapter: ReaderChapter?, lowerReaderChapter: ReaderChapter?): Float {
+    if (higherReaderChapter == null || lowerReaderChapter == null) return 0f
+    return calculateChapterDifference(higherReaderChapter.chapter, lowerReaderChapter.chapter)
 }
 
-fun calculateChapterDifference(higher: Chapter?, lower: Chapter?): Float {
-    if (higher == null || lower == null) return 0f
-    if (!higher.isRecognizedNumber || !lower.isRecognizedNumber) return 0f
-    return calculateChapterDifference(higher.chapter_number, lower.chapter_number)
+fun calculateChapterDifference(higherChapter: Chapter?, lowerChapter: Chapter?): Float {
+    if (higherChapter == null || lowerChapter == null) return 0f
+    // Check if name contains a number that is potential chapter number
+    if (!pattern.containsMatchIn(higherChapter.name) || !pattern.containsMatchIn(lowerChapter.name)) return 0f
+    // Check if potential chapter number was recognized as chapter number
+    if (!higherChapter.isRecognizedNumber || !lowerChapter.isRecognizedNumber) return 0f
+    return calculateChapterDifference(higherChapter.chapter_number, lowerChapter.chapter_number)
 }
 
 fun calculateChapterDifference(higherChapterNumber: Float, lowerChapterNumber: Float): Float {
-    if (higherChapterNumber == 0f || lowerChapterNumber == 0f) return 0f
+    if (higherChapterNumber < 0f || lowerChapterNumber < 0f) return 0f
     return floor(higherChapterNumber) - floor(lowerChapterNumber) - 1f
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderTransitionView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderTransitionView.kt
@@ -12,7 +12,6 @@ import kotlinx.android.synthetic.main.reader_transition_view.view.lower_text
 import kotlinx.android.synthetic.main.reader_transition_view.view.upper_text
 import kotlinx.android.synthetic.main.reader_transition_view.view.warning
 import kotlinx.android.synthetic.main.reader_transition_view.view.warning_text
-import kotlin.math.floor
 
 class ReaderTransitionView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
     LinearLayout(context, attrs) {
@@ -85,20 +84,22 @@ class ReaderTransitionView @JvmOverloads constructor(context: Context, attrs: At
             return
         }
 
-        val fromChapterNumber: Float = floor(transition.from.chapter.chapter_number)
-        val toChapterNumber: Float = floor(transition.to!!.chapter.chapter_number)
-
-        val chapterDifference = when (transition) {
-            is ChapterTransition.Prev -> fromChapterNumber - toChapterNumber - 1f
-            is ChapterTransition.Next -> toChapterNumber - fromChapterNumber - 1f
+        val hasMissingChapters = when (transition) {
+            is ChapterTransition.Prev -> hasMissingChapters(transition.from, transition.to)
+            is ChapterTransition.Next -> hasMissingChapters(transition.to, transition.from)
         }
 
-        val hasMissingChapters = when (transition) {
-            is ChapterTransition.Prev -> MissingChapters.hasMissingChapters(fromChapterNumber, toChapterNumber)
-            is ChapterTransition.Next -> MissingChapters.hasMissingChapters(toChapterNumber, fromChapterNumber)
+        if (!hasMissingChapters) {
+            warning.isVisible = false
+            return
+        }
+
+        val chapterDifference = when (transition) {
+            is ChapterTransition.Prev -> calculateChapterDifference(transition.from, transition.to)
+            is ChapterTransition.Next -> calculateChapterDifference(transition.to, transition.from)
         }
 
         warning_text.text = resources.getQuantityString(R.plurals.missing_chapters_warning, chapterDifference.toInt(), chapterDifference.toInt())
-        warning.isVisible = hasMissingChapters
+        warning.isVisible = true
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
@@ -6,7 +6,7 @@ import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
-import eu.kanade.tachiyomi.ui.reader.viewer.MissingChapters
+import eu.kanade.tachiyomi.ui.reader.viewer.hasMissingChapters
 import eu.kanade.tachiyomi.widget.ViewPagerAdapter
 import timber.log.Timber
 
@@ -35,8 +35,8 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
         val newItems = mutableListOf<Any>()
 
         // Forces chapter transition if there is missing chapters
-        val prevHasMissingChapters = if (chapters.prevChapter != null) MissingChapters.hasMissingChapters(chapters.currChapter.chapter, chapters.prevChapter.chapter) else false
-        val nextHasMissingChapters = if (chapters.nextChapter != null) MissingChapters.hasMissingChapters(chapters.nextChapter.chapter, chapters.currChapter.chapter) else false
+        val prevHasMissingChapters = hasMissingChapters(chapters.currChapter, chapters.prevChapter)
+        val nextHasMissingChapters = hasMissingChapters(chapters.nextChapter, chapters.currChapter)
 
         // Add previous chapter pages and transition.
         if (chapters.prevChapter != null) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -9,7 +9,7 @@ import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
-import eu.kanade.tachiyomi.ui.reader.viewer.MissingChapters
+import eu.kanade.tachiyomi.ui.reader.viewer.hasMissingChapters
 
 /**
  * RecyclerView Adapter used by this [viewer] to where [ViewerChapters] updates are posted.
@@ -31,8 +31,8 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
         val newItems = mutableListOf<Any>()
 
         // Forces chapter transition if there is missing chapters
-        val prevHasMissingChapters = if (chapters.prevChapter != null) MissingChapters.hasMissingChapters(chapters.currChapter.chapter, chapters.prevChapter.chapter) else false
-        val nextHasMissingChapters = if (chapters.nextChapter != null) MissingChapters.hasMissingChapters(chapters.nextChapter.chapter, chapters.currChapter.chapter) else false
+        val prevHasMissingChapters = hasMissingChapters(chapters.currChapter, chapters.prevChapter)
+        val nextHasMissingChapters = hasMissingChapters(chapters.nextChapter, chapters.currChapter)
 
         // Add previous chapter pages and transition.
         if (chapters.prevChapter != null) {


### PR DESCRIPTION
mhrj pointed this out on Discord, [link to message](https://discordapp.com/channels/349436576037732353/566585518171881493/764861993009676288)
| Before | After |
|---|---|
| ![Screenshot_1602430970](https://user-images.githubusercontent.com/6576096/95683064-46eaa380-0be9-11eb-9591-b7b62d45eb43.png) | ![Screenshot_1602431650](https://user-images.githubusercontent.com/6576096/95683313-c75dd400-0bea-11eb-8578-e7dd0a134f8a.png) |

I found that this chapter was recognized as 0. To fix this I added some RegEx to see if the chapter name contains any numbers.
If it doesn't contain any number it returns false. Then it uses isChapterRecognized to see if the number was recognized as a chapter number if it was not then it returns false. Else it continues with the function.
