### PR TITLE
Make list view font size bigger again

### DIFF
--- a/app/src/main/res/layout/source_list_item.xml
+++ b/app/src/main/res/layout/source_list_item.xml
@@ -31,6 +31,7 @@
         android:layout_marginEnd="8dp"
         android:ellipsize="end"
         android:maxLines="1"
+        android:textSize="16sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/badges"
         app:layout_constraintHorizontal_bias="0.007"


### PR DESCRIPTION
Fixes #3967 
The `textSize` for `TextAppearance.Regular.SubHeading` was changed in commit a3c598a.
Since the issue only wants the title for the list item to be bigger again I only changed it to 16sp

