### PR TITLE
Add support for S Pen actions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,7 +60,14 @@
         </activity>
         <activity
             android:name=".ui.reader.ReaderActivity"
-            android:launchMode="singleTask" />
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
+            </intent-filter>
+
+            <meta-data android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/s_pen_actions"/>
+        </activity>
         <activity
             android:name=".ui.security.BiometricUnlockActivity"
             android:theme="@style/Theme.Splash" />

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -261,6 +261,17 @@ class ReaderActivity : BaseRxActivity<ReaderActivityBinding, ReaderPresenter>() 
         super.onBackPressed()
     }
 
+    override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_N) {
+            presenter.loadNextChapter()
+            return true
+        } else if (keyCode == KeyEvent.KEYCODE_P) {
+            presenter.loadPreviousChapter()
+            return true
+        }
+        return super.onKeyUp(keyCode, event)
+    }
+
     /**
      * Dispatches a key event. If the viewer doesn't handle it, call the default implementation.
      */

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -324,6 +324,7 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
      */
     override fun handleKeyEvent(event: KeyEvent): Boolean {
         val isUp = event.action == KeyEvent.ACTION_UP
+        val ctrlPressed = event.metaState.and(KeyEvent.META_CTRL_ON) > 0
 
         when (event.keyCode) {
             KeyEvent.KEYCODE_VOLUME_DOWN -> {
@@ -340,8 +341,16 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
                     if (!config.volumeKeysInverted) moveUp() else moveDown()
                 }
             }
-            KeyEvent.KEYCODE_DPAD_RIGHT -> if (isUp) moveRight()
-            KeyEvent.KEYCODE_DPAD_LEFT -> if (isUp) moveLeft()
+            KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                if (isUp) {
+                    if (ctrlPressed) moveToNext() else moveRight()
+                }
+            }
+            KeyEvent.KEYCODE_DPAD_LEFT -> {
+                if (isUp) {
+                    if (ctrlPressed) moveToPrevious() else moveLeft()
+                }
+            }
             KeyEvent.KEYCODE_DPAD_DOWN -> if (isUp) moveDown()
             KeyEvent.KEYCODE_DPAD_UP -> if (isUp) moveUp()
             KeyEvent.KEYCODE_PAGE_DOWN -> if (isUp) moveDown()

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -401,4 +401,6 @@
     <string name="label_more">Více</string>
     <string name="action_menu">Menu</string>
     <string name="label_sources">Zdroje</string>
+    <string name="spen_previous_page">Předchozí stránka</string>
+    <string name="spen_next_page">Následující stránka</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -719,4 +719,8 @@
     <string name="tapping_inverted_vertical">Vertical</string>
     <string name="tapping_inverted_both">Both</string>
 
+    <!-- S Pen actions -->
+    <string name="spen_previous_page">Previous page</string>
+    <string name="spen_next_page">Next page</string>
+
 </resources>

--- a/app/src/main/res/xml/s_pen_actions.xml
+++ b/app/src/main/res/xml/s_pen_actions.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<remote-actions
+    actionset_label="@string/app_name"
+    version="1.2">
+    <action
+        id="tachiyomi_next_page"
+        label="@string/spen_next_page"
+        priority="1"
+        repeatable="true"
+        repeatable_interval="short"
+        trigger_key="CTRL_LEFT+DPAD_RIGHT">
+        <preference
+            name="gesture"
+            value="click" />
+    </action>
+    <action
+        id="tachiyomi_previous_page"
+        label="@string/spen_previous_page"
+        priority="2"
+        repeatable="true"
+        repeatable_interval="short"
+        trigger_key="CTRL_LEFT+DPAD_LEFT">
+        <preference
+            name="gesture"
+            value="double_click" />
+    </action>
+    <action
+        id="tachiyomi_back"
+        label="@string/action_webview_back"
+        priority="3"
+        repeatable="true"
+        repeatable_interval="short"
+        trigger_key="BACK">
+        <preference
+            name="gesture"
+            value="circle_ccw" />
+    </action>
+    <action
+        id="tachiyomi_next_chapter"
+        label="@string/action_next_chapter"
+        priority="4"
+        repeatable="true"
+        repeatable_interval="short"
+        trigger_key="N">
+        <preference
+            name="gesture"
+            value="swipe_right" />
+    </action>
+    <action
+        id="tachiyomi_previous_chapter"
+        label="@string/action_previous_chapter"
+        priority="5"
+        repeatable="true"
+        repeatable_interval="short"
+        trigger_key="P">
+        <preference
+            name="gesture"
+            value="swipe_left" />
+    </action>
+</remote-actions>


### PR DESCRIPTION
Adds support for S Pen Air Actions for Galaxy Note 10 and newer devices. This basically allows you to use the pen to do some gestures and respond with actions - each gesture is converted to a key event that is sent to the app.

Only one activity can handle Air Actions in the app, Reader seemed the most useful to me.

All actions are configurable in the settings, the `<preference />` xml tag is only the default which can be changed by user.

<img src="https://user-images.githubusercontent.com/13106547/98948182-66c9fb80-24f6-11eb-9d26-7b4ff0c5296c.jpg" width="200" />  <img src="https://user-images.githubusercontent.com/13106547/98948187-67fb2880-24f6-11eb-8b0a-06b06e6c83ec.jpg" width="200" />

If there are any other actions that you think would make sense in a reader, let me know, I can implement them.

The actions:

- **Next page** - default air action is single button press because it's probably the most used action
- **Previous page** - default air action is double button press
- **Next chapter** - default air action is swipe right
- **Previous chapter** - default air action is swipe left
- **Back** - default air action is counter clockwise circle

Available air actions (let me know if you think other default action makes sense):

- Single click
- Double click
- Swipe left
- Swipe right
- Swipe up
- Swipe down
- Circle Counter-clock-wise 
- Circle Clock-wise 

Also the app actions can be restricted to only button actions (single click, double click) or only motion actions, but I think there's no point in restricting these actions.

The official documentation is available here: https://developer.samsung.com/galaxy-spen-remote/air-actions.html