### PR TITLE
Enhance incognito mode

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourceController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourceController.kt
@@ -196,7 +196,9 @@ class SourceController :
      * Opens a catalogue with the given controller.
      */
     private fun openSource(source: CatalogueSource, controller: BrowseSourceController) {
-        preferences.lastUsedSource().set(source.id)
+        if (!preferences.incognitoMode().get()) {
+            preferences.lastUsedSource().set(source.id)
+        }
         parentController!!.router.pushController(controller.withFadeTransaction())
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -407,17 +407,19 @@ class ReaderPresenter(
     }
 
     /**
-     * Saves this [chapter] progress (last read page and whether it's read).
+     * Saves this [chapter] progress (last read page and whether it's read) if incognito mode isn't on.
      */
     private fun saveChapterProgress(chapter: ReaderChapter) {
-        db.updateChapterProgress(chapter.chapter).asRxCompletable()
-            .onErrorComplete()
-            .subscribeOn(Schedulers.io())
-            .subscribe()
+        if (!preferences.incognitoMode().get()) {
+            db.updateChapterProgress(chapter.chapter).asRxCompletable()
+                .onErrorComplete()
+                .subscribeOn(Schedulers.io())
+                .subscribe()
+        }
     }
 
     /**
-     * Saves this [chapter] last read history.
+     * Saves this [chapter] last read history if incognito mode isn't on.
      */
     private fun saveChapterHistory(chapter: ReaderChapter) {
         if (!preferences.incognitoMode().get()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -133,6 +133,13 @@ class ReaderPresenter(
         }.map(::ReaderChapter)
     }
 
+    private var hasTrackers: Boolean = false
+    private val checkTrackers: (Manga) -> Unit = { manga ->
+        val tracks = db.getTracks(manga).executeAsBlocking()
+
+        hasTrackers = tracks.size > 0
+    }
+
     /**
      * Called when the presenter is created. It retrieves the saved active chapter if the process
      * was restored.
@@ -223,6 +230,8 @@ class ReaderPresenter(
 
         this.manga = manga
         if (chapterId == -1L) chapterId = initialChapterId
+
+        checkTrackers(manga)
 
         val context = Injekt.get<Application>()
         val source = sourceManager.getOrStub(manga.source)
@@ -357,7 +366,8 @@ class ReaderPresenter(
 
         // Save last page read and mark as read if needed
         selectedChapter.chapter.last_page_read = page.index
-        if (selectedChapter.pages?.lastIndex == page.index) {
+        val shouldTrack = !preferences.incognitoMode().get() || hasTrackers
+        if (selectedChapter.pages?.lastIndex == page.index && shouldTrack) {
             selectedChapter.chapter.read = true
             updateTrackChapterRead(selectedChapter)
             deleteChapterIfNeeded(selectedChapter)
@@ -407,10 +417,11 @@ class ReaderPresenter(
     }
 
     /**
-     * Saves this [chapter] progress (last read page and whether it's read) if incognito mode isn't on.
+     * Saves this [chapter] progress (last read page and whether it's read).
+     * If incognito mode isn't on or has at least 1 tracker
      */
     private fun saveChapterProgress(chapter: ReaderChapter) {
-        if (!preferences.incognitoMode().get()) {
+        if (!preferences.incognitoMode().get() || hasTrackers) {
             db.updateChapterProgress(chapter.chapter).asRxCompletable()
                 .onErrorComplete()
                 .subscribeOn(Schedulers.io())


### PR DESCRIPTION
Changes some behavior when in Incognito Mode.

Added behavior
- Does not add the source to last used when opening it
- Does not save chapter progress (overwritten if the manga is being tracked by a tracker)

For example, when opening a source to browse it that will not add it to last used. Also when reading a chapter and exiting/(reading to the last page) it will not save the progress unless it is being tracked.